### PR TITLE
fix(Expression): Escape double quotes and slashes in values

### DIFF
--- a/src/files/rsql-filter-expression.ts
+++ b/src/files/rsql-filter-expression.ts
@@ -25,6 +25,7 @@ export class RSQLFilterExpression {
     let valueString: string = '';
     if (isString(this.value)) {
       valueString = this.value;
+      valueString = valueString.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
     }
     if (isNumber(this.value)) {
       valueString = this.value.toString();
@@ -36,6 +37,9 @@ export class RSQLFilterExpression {
       let quotedValues = this.value.filter(i => i !== undefined).map(i => {
         if (isNumber(i)) {
           return i;
+        } else if (isString(i)) {
+          let val = i.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+          return encodeURIComponent(this.quote(val));
         } else {
           return encodeURIComponent(this.quote(i));
         }

--- a/test/rsql-filter-expresion.test.ts
+++ b/test/rsql-filter-expresion.test.ts
@@ -8,6 +8,15 @@ describe('RSQLFilterExpression', () => {
 
     ex = new RSQLFilterExpression('code', Operators.Equal, false);
     expect(ex.build()).toEqual(`code==${encodeURIComponent('"false"')}`);
+
+    ex = new RSQLFilterExpression('code', Operators.Equal, 'ab"c');
+    expect(ex.build()).toEqual(`code==%22ab%5C%22c%22`);
+
+    ex = new RSQLFilterExpression('code', Operators.Equal, 'ab\\c');
+    expect(ex.build()).toEqual(`code==%22ab%5C%5Cc%22`);
+
+    ex = new RSQLFilterExpression('code', Operators.Equal, 'ab\\"c');
+    expect(ex.build()).toEqual(`code==%22ab%5C%5C%5C%22c%22`);
   });
 
   it('should handle the Equals operator when our value is null', () => {
@@ -100,6 +109,9 @@ describe('RSQLFilterExpression', () => {
     expect(ex.build()).toEqual(
       `code=in=(${encodeURIComponent('"123"')},${encodeURIComponent('"456"')})`
     );
+
+    ex = new RSQLFilterExpression('code', Operators.In, ['ab"c', 'ab\\c', 'ab\\"c']);
+    expect(ex.build()).toEqual(`code=in=(%22ab%5C%22c%22,%22ab%5C%5Cc%22,%22ab%5C%5C%5C%22c%22)`);
   });
 
   it('should handle the In operator with only numbers', () => {


### PR DESCRIPTION
This should prevent server parsing errors where the double quotes aren't properly escaped.