### PR TITLE
feat(Expression): Make equalTo be strictly equal.  Add like operation…

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,20 +59,25 @@ rsql.build();
 // returns $where=(blah=="123" or test=="456")
  ```
 
- ### Combining multiple RSQLCriteria Instances
- You can combine multiple RSQLCriteria instances by the `and` or `or` functions that are available.  The major thing to know about this is that the criteria that you call `and` or `or` on will be the one that the pagination and order by parts will be taken from.  The combination is a way to combine the filters together in a nice fashion.
- ```javascript
- let criteria1 = new RSQLCriteria();
- criteria1.pageSize = 10;
- let criteria2 = new RSQLCriteria();
- criteria2.pageSize = 5;
- criteria1.and(criteria2);
- criteria1.build();
- //returns $pageSize=10 instead of pageSize = 5
- ```
+### Combining multiple RSQLCriteria Instances
+You can combine multiple RSQLCriteria instances by the `and` or `or` functions that are available.  The major thing to know about this is that the criteria that you call `and` or `or` on will be the one that the pagination and order by parts will be taken from.  The combination is a way to combine the filters together in a nice fashion.
+```javascript
+let criteria1 = new RSQLCriteria();
+criteria1.pageSize = 10;
+let criteria2 = new RSQLCriteria();
+criteria2.pageSize = 5;
+criteria1.and(criteria2);
+criteria1.build();
+//returns $pageSize=10 instead of pageSize = 5
+```
 
- ### Other examples
- Other examples can be found in the tests folder.  Many usages already have tests wrapped around them.
+### A note on function names
+This library has been tested against a SQL Server backend and some irregularities have been found.  A RSQL `==` operation turns into a `LIKE` in SQL Server so that wildcard characters are available for use.  However, in most other languages an `equals` operation is an exact match.  To handle this, the `Operators.Equal` and `RSQLFilterBuilder.equalTo` methods will create an `=in=` RSQL string.  This doesn't allow wildcards to be used in and will intuitively make more sense for those of us that are used to equals meaning exactly equal to.  Wildcard characters are still allowed to be passed in, but they will be interpretted as the characters themselves and not wildcards.
+
+To allow wildcards to be used, another operation and function are available.  `Operators.Like` and `RSQLFilterBuilder.like` will use the RSQL `==` and allow wildcard characters to be passed along.
+
+### Other examples
+Other examples can be found in the tests folder.  Many usages already have tests wrapped around them.
 
 
 ## Acknowledgements

--- a/src/files/rsql-expression-parts.ts
+++ b/src/files/rsql-expression-parts.ts
@@ -8,6 +8,7 @@ export interface RSQLFilter {
 export interface RSQLColumn {
   equalTo(value: string | Date | number | boolean): RSQLCompleteExpression;
   notEqualTo(value: string | Date | number | boolean): RSQLCompleteExpression;
+  like(value: string): RSQLCompleteExpression;
   contains(value: string | Date | number): RSQLCompleteExpression;
   doesNotContain(value: string | Date | number): RSQLCompleteExpression;
   startsWith(value: string): RSQLCompleteExpression;

--- a/src/files/rsql-filter-builder.ts
+++ b/src/files/rsql-filter-builder.ts
@@ -63,6 +63,12 @@ export class RSQLFilterBuilder implements RSQLFilter, RSQLColumn, RSQLCompleteEx
     return this;
   }
 
+  like(value: string): RSQLCompleteExpression {
+    this.operator = Operators.Like;
+    this.value = value;
+    return this;
+  }
+
   contains(value: string | number | Date): RSQLCompleteExpression {
     this.operator = Operators.Contains;
     this.value = value;

--- a/src/files/rsql-filter-expression.ts
+++ b/src/files/rsql-filter-expression.ts
@@ -21,11 +21,13 @@ export class RSQLFilterExpression {
    */
   public build(): string {
     let filterString = '';
+    let shouldQuote = false;
     // convert the value into an appropriate string.
     let valueString: string = '';
     if (isString(this.value)) {
       valueString = this.value;
       valueString = valueString.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+      shouldQuote = true;
     }
     if (isNumber(this.value)) {
       valueString = this.value.toString();
@@ -52,6 +54,7 @@ export class RSQLFilterExpression {
         this.value.getMonth() + 1,
         this.value.getDate()
       ].join('-');
+      shouldQuote = true;
     }
     if (this.value === null) {
       valueString = 'null';
@@ -60,10 +63,15 @@ export class RSQLFilterExpression {
     filterString += this.field;
     switch (this.operator) {
       case Operators.Equal:
-        filterString += '==' + encodeURIComponent(this.quote(valueString));
+        filterString +=
+          '=in=' + encodeURIComponent(shouldQuote ? this.quote(valueString) : valueString);
         break;
       case Operators.NotEqual:
-        filterString += '!=' + encodeURIComponent(this.quote(valueString));
+        filterString +=
+          '!=' + encodeURIComponent(shouldQuote ? this.quote(valueString) : valueString);
+        break;
+      case Operators.Like:
+        filterString += '==' + encodeURIComponent(this.quote(valueString));
         break;
       case Operators.GreaterThan:
         filterString += encodeURIComponent('>') + valueString;

--- a/src/files/rsql-filter-operators.ts
+++ b/src/files/rsql-filter-operators.ts
@@ -1,6 +1,7 @@
 export enum Operators {
   Equal = 'eq',
   NotEqual = 'neq',
+  Like = 'like',
   IsNull = 'isnull',
   IsNotNull = 'isnotnull',
   GreaterThan = 'gt',

--- a/test/rsql-criteria.test.ts
+++ b/test/rsql-criteria.test.ts
@@ -20,7 +20,7 @@ describe('RSQLCriteria test', () => {
   it('should build a where clause when filters are passed in', () => {
     let criteria = new RSQLCriteria();
     criteria.filters.and(new RSQLFilterExpression('code', Operators.Equal, 'abc'));
-    expect(criteria.build()).toEqual(`$where=code==${encodeURIComponent('"abc"')}`);
+    expect(criteria.build()).toEqual(`$where=code=in=${encodeURIComponent('"abc"')}`);
   });
 
   it('should build an orderBy clause when order by expressions are passed in', () => {
@@ -34,7 +34,7 @@ describe('RSQLCriteria test', () => {
     criteria.orderBy.add('code', 'asc');
     criteria.filters.and(new RSQLFilterExpression('code', Operators.Equal, 'abc'));
     expect(criteria.build()).toEqual(
-      `$where=code==${encodeURIComponent('"abc"')}&$orderBy=${encodeURIComponent('code asc')}`
+      `$where=code=in=${encodeURIComponent('"abc"')}&$orderBy=${encodeURIComponent('code asc')}`
     );
   });
 
@@ -47,7 +47,7 @@ describe('RSQLCriteria test', () => {
   it('should build a where clause when filters are passed in with a customized where keyword', () => {
     let criteria = new RSQLCriteria('$filter');
     criteria.filters.and(new RSQLFilterExpression('code', Operators.Equal, 'abc'));
-    expect(criteria.build()).toEqual(`$filter=code==${encodeURIComponent('"abc"')}`);
+    expect(criteria.build()).toEqual(`$filter=code=in=${encodeURIComponent('"abc"')}`);
   });
 
   it('should add in pageSize when that has been set.', () => {

--- a/test/rsql-filter-builder.test.ts
+++ b/test/rsql-filter-builder.test.ts
@@ -8,7 +8,7 @@ describe('RSQLFilterBuilder', () => {
       .column('blah')
       .equalTo('123')
       .toList();
-    expect(list.build()).toEqual(`blah==${encodeURIComponent('"123"')}`);
+    expect(list.build()).toEqual(`blah=in=${encodeURIComponent('"123"')}`);
   });
 
   it('should build a single filter properly by casting the result of the RSQLFilterBuilder to the RSQLFilter interface', () => {
@@ -17,7 +17,7 @@ describe('RSQLFilterBuilder', () => {
       .column('blah')
       .equalTo('123')
       .toList();
-    expect(list.build()).toEqual(`blah==${encodeURIComponent('"123"')}`);
+    expect(list.build()).toEqual(`blah=in=${encodeURIComponent('"123"')}`);
   });
 
   it('should build a set of filters with an and', () => {
@@ -30,9 +30,9 @@ describe('RSQLFilterBuilder', () => {
       .equalTo('John')
       .toList();
     expect(list.build()).toEqual(
-      `(blah==${encodeURIComponent('"123"')}${encodeURIComponent(
+      `(blah=in=${encodeURIComponent('"123"')}${encodeURIComponent(
         ' and '
-      )}name==${encodeURIComponent('"John"')})`
+      )}name=in=${encodeURIComponent('"John"')})`
     );
   });
 
@@ -46,9 +46,9 @@ describe('RSQLFilterBuilder', () => {
       .equalTo('John')
       .toList();
     expect(list.build()).toEqual(
-      `(blah==${encodeURIComponent('"123"')}${encodeURIComponent(' or ')}name==${encodeURIComponent(
-        '"John"'
-      )})`
+      `(blah=in=${encodeURIComponent('"123"')}${encodeURIComponent(
+        ' or '
+      )}name=in=${encodeURIComponent('"John"')})`
     );
   });
 
@@ -62,9 +62,9 @@ describe('RSQLFilterBuilder', () => {
       .equalTo('John')
       .toList();
     expect(list.build()).toEqual(
-      `(blah==${encodeURIComponent('"123"')}${encodeURIComponent(' or ')}name==${encodeURIComponent(
-        '"John"'
-      )})`
+      `(blah=in=${encodeURIComponent('"123"')}${encodeURIComponent(
+        ' or '
+      )}name=in=${encodeURIComponent('"John"')})`
     );
 
     builder.clear();
@@ -72,7 +72,7 @@ describe('RSQLFilterBuilder', () => {
       .column('blah')
       .equalTo('123')
       .toList();
-    expect(list.build()).toEqual(`blah==${encodeURIComponent('"123"')}`);
+    expect(list.build()).toEqual(`blah=in=${encodeURIComponent('"123"')}`);
   });
 
   it('should handle the clear function for complex functions', () => {
@@ -85,9 +85,9 @@ describe('RSQLFilterBuilder', () => {
       .equalTo('John')
       .toList();
     expect(list.build()).toEqual(
-      `(blah==${encodeURIComponent('"123"')}${encodeURIComponent(' or ')}name==${encodeURIComponent(
-        '"John"'
-      )})`
+      `(blah=in=${encodeURIComponent('"123"')}${encodeURIComponent(
+        ' or '
+      )}name=in=${encodeURIComponent('"John"')})`
     );
 
     builder.clear();
@@ -99,9 +99,9 @@ describe('RSQLFilterBuilder', () => {
       .equalTo('John')
       .toList();
     expect(list.build()).toEqual(
-      `(blah2==${encodeURIComponent('"123"')}${encodeURIComponent(
+      `(blah2=in=${encodeURIComponent('"123"')}${encodeURIComponent(
         ' or '
-      )}name2==${encodeURIComponent('"John"')})`
+      )}name2=in=${encodeURIComponent('"John"')})`
     );
   });
 
@@ -111,14 +111,14 @@ describe('RSQLFilterBuilder', () => {
       .column('blah')
       .equalTo('123')
       .toList();
-    expect(list.build()).toEqual(`blah==${encodeURIComponent('"123"')}`);
+    expect(list.build()).toEqual(`blah=in=${encodeURIComponent('"123"')}`);
 
     builder.clear();
     list = builder
       .column('blah')
       .equalTo(true)
       .toList();
-    expect(list.build()).toEqual(`blah==${encodeURIComponent('"true"')}`);
+    expect(list.build()).toEqual(`blah=in=true`);
   });
 
   it('should build the proper string for the notEqualTo function', () => {
@@ -128,6 +128,15 @@ describe('RSQLFilterBuilder', () => {
       .notEqualTo('123')
       .toList();
     expect(list.build()).toEqual(`blah!=${encodeURIComponent('"123"')}`);
+  });
+
+  it('should build the proper string for the like function', () => {
+    let builder: RSQLFilter = new RSQLFilterBuilder();
+    let list = builder
+      .column('blah')
+      .like('123')
+      .toList();
+    expect(list.build()).toEqual(`blah==${encodeURIComponent('"123"')}`);
   });
 
   it('should build the proper string for the contains function', () => {

--- a/test/rsql-filter-expresion.test.ts
+++ b/test/rsql-filter-expresion.test.ts
@@ -4,37 +4,48 @@ import { Operators } from '../src/files/rsql-filter-operators';
 describe('RSQLFilterExpression', () => {
   it('should handle the Equals operator', () => {
     let ex = new RSQLFilterExpression('code', Operators.Equal, '123');
-    expect(ex.build()).toEqual(`code==${encodeURIComponent('"123"')}`);
+    expect(ex.build()).toEqual(`code=in=${encodeURIComponent('"123"')}`);
 
     ex = new RSQLFilterExpression('code', Operators.Equal, false);
-    expect(ex.build()).toEqual(`code==${encodeURIComponent('"false"')}`);
+    expect(ex.build()).toEqual(`code=in=false`);
 
     ex = new RSQLFilterExpression('code', Operators.Equal, 'ab"c');
-    expect(ex.build()).toEqual(`code==%22ab%5C%22c%22`);
+    expect(ex.build()).toEqual(`code=in=%22ab%5C%22c%22`);
 
     ex = new RSQLFilterExpression('code', Operators.Equal, 'ab\\c');
-    expect(ex.build()).toEqual(`code==%22ab%5C%5Cc%22`);
+    expect(ex.build()).toEqual(`code=in=%22ab%5C%5Cc%22`);
 
     ex = new RSQLFilterExpression('code', Operators.Equal, 'ab\\"c');
-    expect(ex.build()).toEqual(`code==%22ab%5C%5C%5C%22c%22`);
+    expect(ex.build()).toEqual(`code=in=%22ab%5C%5C%5C%22c%22`);
+
+    ex = new RSQLFilterExpression('code', Operators.Equal, 123);
+    expect(ex.build()).toEqual(`code=in=123`);
   });
 
   it('should handle the Equals operator when our value is null', () => {
     let ex = new RSQLFilterExpression('code', Operators.Equal, null);
-    expect(ex.build()).toEqual(`code==${encodeURIComponent('"null"')}`);
+    expect(ex.build()).toEqual(`code=in=null`);
   });
 
   it('should handle the NotEquals operator when our value is null', () => {
     let ex = new RSQLFilterExpression('code', Operators.NotEqual, null);
-    expect(ex.build()).toEqual(`code!=${encodeURIComponent('"null"')}`);
+    expect(ex.build()).toEqual(`code!=null`);
   });
 
   it('should handle the NotEquals operator', () => {
     let ex = new RSQLFilterExpression('code', Operators.NotEqual, '123');
     expect(ex.build()).toEqual(`code!=${encodeURIComponent('"123"')}`);
 
-    ex = new RSQLFilterExpression('code', Operators.Equal, true);
-    expect(ex.build()).toEqual(`code==${encodeURIComponent('"true"')}`);
+    ex = new RSQLFilterExpression('code', Operators.NotEqual, true);
+    expect(ex.build()).toEqual(`code!=true`);
+  });
+
+  it('should handle the Like operator', () => {
+    let ex = new RSQLFilterExpression('code', Operators.Like, 'abc');
+    expect(ex.build()).toEqual(`code==${encodeURIComponent('"abc"')}`);
+
+    ex = new RSQLFilterExpression('code', Operators.Like, 'ab_d');
+    expect(ex.build()).toEqual(`code==${encodeURIComponent('"ab_d"')}`);
   });
 
   it('should handle the IsNull operator', () => {

--- a/test/rsql-filter-list.test.ts
+++ b/test/rsql-filter-list.test.ts
@@ -6,7 +6,7 @@ describe('RSQLFilterList', () => {
   it('should create a string with just one filter expression in it', () => {
     let list = new RSQLFilterList();
     list.and(new RSQLFilterExpression('code', Operators.Equal, '123'));
-    expect(list.build()).toEqual(`code==${encodeURIComponent('"123"')}`);
+    expect(list.build()).toEqual(`code=in=${encodeURIComponent('"123"')}`);
   });
 
   it('should bring together two expression with an AND by default', () => {
@@ -14,7 +14,7 @@ describe('RSQLFilterList', () => {
     list.and(new RSQLFilterExpression('code', Operators.Equal, '123'));
     list.and(new RSQLFilterExpression('description', Operators.NotEqual, '456'));
     expect(list.build()).toEqual(
-      `(code==${encodeURIComponent('"123"')}${encodeURIComponent(
+      `(code=in=${encodeURIComponent('"123"')}${encodeURIComponent(
         ' and '
       )}description!=${encodeURIComponent('"456"')})`
     );
@@ -25,7 +25,7 @@ describe('RSQLFilterList', () => {
     list.or(new RSQLFilterExpression('code', Operators.Equal, '123'));
     list.or(new RSQLFilterExpression('description', Operators.NotEqual, '456'));
     expect(list.build()).toEqual(
-      `(code==${encodeURIComponent('"123"')}${encodeURIComponent(
+      `(code=in=${encodeURIComponent('"123"')}${encodeURIComponent(
         ' or '
       )}description!=${encodeURIComponent('"456"')})`
     );
@@ -42,13 +42,13 @@ describe('RSQLFilterList', () => {
     list.or(ex1);
     list.or(ex2);
     expect(list.build()).toEqual(
-      `((firstName==${encodeURIComponent('"John"')}${encodeURIComponent(
+      `((firstName=in=${encodeURIComponent('"John"')}${encodeURIComponent(
         ' and '
-      )}lastName==${encodeURIComponent('"Doe"')})${encodeURIComponent(
+      )}lastName=in=${encodeURIComponent('"Doe"')})${encodeURIComponent(
         ' or '
-      )}(firstName==${encodeURIComponent('"Jane"')}${encodeURIComponent(
+      )}(firstName=in=${encodeURIComponent('"Jane"')}${encodeURIComponent(
         ' and '
-      )}lastName==${encodeURIComponent('"Deer"')}))`
+      )}lastName=in=${encodeURIComponent('"Deer"')}))`
     );
   });
 
@@ -59,11 +59,11 @@ describe('RSQLFilterList', () => {
     list.or(new RSQLFilterExpression('code', Operators.Equal, '123'));
     list.or(new RSQLFilterExpression('description', Operators.NotEqual, '456'));
     expect(list.build()).toEqual(
-      `(firstName==${encodeURIComponent('"abc"')}${encodeURIComponent(
+      `(firstName=in=${encodeURIComponent('"abc"')}${encodeURIComponent(
         ' and '
-      )}lastName==${encodeURIComponent('"def"')}${encodeURIComponent(
+      )}lastName=in=${encodeURIComponent('"def"')}${encodeURIComponent(
         ' or '
-      )}code==${encodeURIComponent('"123"')}${encodeURIComponent(
+      )}code=in=${encodeURIComponent('"123"')}${encodeURIComponent(
         ' or '
       )}description!=${encodeURIComponent('"456"')})`
     );


### PR DESCRIPTION
… to support wildcards

User input can now be passed directly to the equalTo function and wildcard characters will be
interpretted as the characters themselves rather than the wildcards.  A like function and Operation
has been added to support wildcard searches.

BREAKING CHANGE: The Operators.Equal and RSQLFilterBuilder.equalTo methods now create an RSQL =in=
rather than == like they used to.  If you continue to need the == functionality, switch over to the
Operators.Like or RSQLFilterBuilder.like method.