### PR TITLE
fix(FilterList): make sure the filter that is coming in isn't blank before adding it to the filter list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1750,11 +1750,6 @@
       "integrity": "sha1-X6rZwsB/YN12dw9xzwJbYqY8/U4=",
       "dev": true
     },
-    "abbrev": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-    },
     "acorn": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.4.1.tgz",
@@ -1801,6 +1796,7 @@
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "dev": true,
       "requires": {
         "co": "4.6.0",
         "fast-deep-equal": "1.0.0",
@@ -1829,6 +1825,7 @@
       "version": "2.0.0",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/ansi-align/-/ansi-align-2.0.0.tgz",
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
+      "dev": true,
       "requires": {
         "string-width": "2.1.1"
       },
@@ -1836,17 +1833,20 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -1856,6 +1856,7 @@
           "version": "4.0.0",
           "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
           }
@@ -1871,12 +1872,14 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
     },
     "ansicolors": {
       "version": "0.3.2",
@@ -1915,29 +1918,11 @@
         "default-require-extensions": "1.0.0"
       }
     },
-    "aproba": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
-    },
-    "arch": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.1.1.tgz",
-      "integrity": "sha512-BLM56aPo9vLLFVa8+/+pJLnrZ7QGGTVHWsCwieAWT9o9K8UeGaQbzZbGoabWLOo2ksBCztoXdqBZBplqLDDCSg=="
-    },
-    "are-we-there-yet": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.4.tgz",
-      "integrity": "sha1-u13KOCu5TwXhUZQ3PRb9O6HKEQ0=",
-      "requires": {
-        "delegates": "1.0.0",
-        "readable-stream": "2.3.3"
-      }
-    },
     "argparse": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+      "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
       }
@@ -2035,12 +2020,14 @@
     "asn1": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
-      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y=",
+      "dev": true
     },
     "assert-plus": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -2078,7 +2065,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "atob": {
       "version": "2.0.3",
@@ -2089,17 +2077,20 @@
     "aws-sign2": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+      "dev": true
     },
     "aws4": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
-      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
+      "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+      "dev": true
     },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
       "requires": {
         "chalk": "1.1.3",
         "esutils": "2.0.2",
@@ -2110,6 +2101,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.0.tgz",
       "integrity": "sha1-rzL3izGm/O8RnIew/Y2XU/A6C7g=",
+      "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
         "babel-generator": "6.26.0",
@@ -2135,7 +2127,8 @@
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         }
       }
     },
@@ -2143,6 +2136,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.0.tgz",
       "integrity": "sha1-rBriAHC3n248odMmlhMFN3TyDcU=",
+      "dev": true,
       "requires": {
         "babel-messages": "6.23.0",
         "babel-runtime": "6.26.0",
@@ -2157,144 +2151,16 @@
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         }
-      }
-    },
-    "babel-helper-builder-binary-assignment-operator-visitor": {
-      "version": "6.24.1",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
-      "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-      "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-call-delegate": {
-      "version": "6.24.1",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
-      "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-define-map": {
-      "version": "6.26.0",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
-      "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.10"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha1-G3eTz3JZ6jj7NmHU04syYK+K5Oc="
-        }
-      }
-    },
-    "babel-helper-explode-assignable-expression": {
-      "version": "6.24.1",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
-      "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-function-name": {
-      "version": "6.24.1",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-get-function-arity": {
-      "version": "6.24.1",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-hoist-variables": {
-      "version": "6.24.1",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
-      "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-optimise-call-expression": {
-      "version": "6.24.1",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
-      "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-regex": {
-      "version": "6.26.0",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
-      "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.10"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha1-G3eTz3JZ6jj7NmHU04syYK+K5Oc="
-        }
-      }
-    },
-    "babel-helper-remap-async-to-generator": {
-      "version": "6.24.1",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-helper-replace-supers": {
-      "version": "6.24.1",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
-      "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-      "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
       }
     },
     "babel-helpers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-template": "6.26.0"
@@ -2304,14 +2170,7 @@
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
       "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-check-es2015-constants": {
-      "version": "6.22.0",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
-      "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0"
       }
@@ -2333,154 +2192,17 @@
       "integrity": "sha512-NwicD5n1YQaj6sM3PVULdPBDk1XdlWvh8xBeUJg3nqZwp79Vofb8Q7GOVeWoZZ/RMlMuJMMrEAgSQl/p392nLA==",
       "dev": true
     },
-    "babel-plugin-syntax-async-functions": {
-      "version": "6.13.0",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
-    },
-    "babel-plugin-syntax-exponentiation-operator": {
-      "version": "6.13.0",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-syntax-exponentiation-operator/-/babel-plugin-syntax-exponentiation-operator-6.13.0.tgz",
-      "integrity": "sha1-nufoM3KQ2pUoggGmpX9BcDF4MN4="
-    },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
-    "babel-plugin-syntax-trailing-function-commas": {
-      "version": "6.22.0",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-syntax-trailing-function-commas/-/babel-plugin-syntax-trailing-function-commas-6.22.0.tgz",
-      "integrity": "sha1-ugNgk3+NBuQBgKQ/4NVhb/9TLPM="
-    },
-    "babel-plugin-transform-async-to-generator": {
-      "version": "6.24.1",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-      "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-arrow-functions": {
-      "version": "6.22.0",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
-      "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-block-scoped-functions": {
-      "version": "6.22.0",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
-      "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-block-scoping": {
-      "version": "6.26.0",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
-      "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.10"
-      },
-      "dependencies": {
-        "lodash": {
-          "version": "4.17.10",
-          "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/lodash/-/lodash-4.17.10.tgz",
-          "integrity": "sha1-G3eTz3JZ6jj7NmHU04syYK+K5Oc="
-        }
-      }
-    },
-    "babel-plugin-transform-es2015-classes": {
-      "version": "6.24.1",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
-      "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-      "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-computed-properties": {
-      "version": "6.24.1",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
-      "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-destructuring": {
-      "version": "6.23.0",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
-      "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-duplicate-keys": {
-      "version": "6.24.1",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
-      "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-for-of": {
-      "version": "6.23.0",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
-      "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-function-name": {
-      "version": "6.24.1",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
-      "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-literals": {
-      "version": "6.22.0",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
-      "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-amd": {
-      "version": "6.24.1",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
-      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-      "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
-    },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
       "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+      "dev": true,
       "requires": {
         "babel-plugin-transform-strict-mode": "6.24.1",
         "babel-runtime": "6.26.0",
@@ -2488,180 +2210,14 @@
         "babel-types": "6.26.0"
       }
     },
-    "babel-plugin-transform-es2015-modules-systemjs": {
-      "version": "6.24.1",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
-      "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-modules-umd": {
-      "version": "6.24.1",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
-      "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-      "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-object-super": {
-      "version": "6.24.1",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
-      "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-      "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-parameters": {
-      "version": "6.24.1",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
-      "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-shorthand-properties": {
-      "version": "6.24.1",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
-      "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-spread": {
-      "version": "6.22.0",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
-      "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-sticky-regex": {
-      "version": "6.24.1",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
-      "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-template-literals": {
-      "version": "6.22.0",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
-      "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-typeof-symbol": {
-      "version": "6.23.0",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
-      "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-es2015-unicode-regex": {
-      "version": "6.24.1",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
-      "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
-      }
-    },
-    "babel-plugin-transform-exponentiation-operator": {
-      "version": "6.24.1",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
-      "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-      "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.26.0"
-      }
-    },
-    "babel-plugin-transform-regenerator": {
-      "version": "6.26.0",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
-      "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-      "requires": {
-        "regenerator-transform": "0.10.1"
-      }
-    },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0"
-      }
-    },
-    "babel-polyfill": {
-      "version": "6.26.0",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
-      "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.10.5"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.10.5",
-          "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/regenerator-runtime/-/regenerator-runtime-0.10.5.tgz",
-          "integrity": "sha1-M2w+/BIgrc7dosn6tntaeVWjNlg="
-        }
-      }
-    },
-    "babel-preset-env": {
-      "version": "1.7.0",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
-      "integrity": "sha1-3qefpOvriDzTXasH4mDBycBN93o=",
-      "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "3.2.8",
-        "invariant": "2.2.2",
-        "semver": "5.4.1"
       }
     },
     "babel-preset-jest": {
@@ -2678,6 +2234,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
+      "dev": true,
       "requires": {
         "babel-core": "6.26.0",
         "babel-runtime": "6.26.0",
@@ -2691,7 +2248,8 @@
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         }
       }
     },
@@ -2699,6 +2257,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true,
       "requires": {
         "core-js": "2.5.1",
         "regenerator-runtime": "0.11.0"
@@ -2708,6 +2267,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
       "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "babel-traverse": "6.26.0",
@@ -2719,7 +2279,8 @@
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         }
       }
     },
@@ -2727,6 +2288,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
         "babel-messages": "6.23.0",
@@ -2742,7 +2304,8 @@
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         }
       }
     },
@@ -2750,6 +2313,7 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
       "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true,
       "requires": {
         "babel-runtime": "6.26.0",
         "esutils": "2.0.2",
@@ -2760,19 +2324,22 @@
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         }
       }
     },
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
     },
     "base": {
       "version": "0.11.2",
@@ -2841,18 +2408,11 @@
         }
       }
     },
-    "base32": {
-      "version": "0.0.6",
-      "resolved": "https://registry.npmjs.org/base32/-/base32-0.0.6.tgz",
-      "integrity": "sha1-eQOLy1rsLY8ivMHChAKST1Cm0qw=",
-      "requires": {
-        "optimist": "0.6.1"
-      }
-    },
     "bcrypt-pbkdf": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "dev": true,
       "optional": true,
       "requires": {
         "tweetnacl": "0.14.5"
@@ -2870,57 +2430,11 @@
       "integrity": "sha1-RqoXUftqL5PuXmibsQh9SxTGwgU=",
       "dev": true
     },
-    "bl": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
-      "integrity": "sha512-e8tQYnZodmebYDWGH7KMRvtzKXaJHx3BbilrgZCfvyLUYdKpK1t5PSPmpkny/SgiTSCnjfLW7v5rlONXVFkQEA==",
-      "optional": true,
-      "requires": {
-        "readable-stream": "2.3.6",
-        "safe-buffer": "5.1.1"
-      },
-      "dependencies": {
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-          "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
-          "optional": true
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
-          "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-          "optional": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        }
-      }
-    },
-    "bluebird": {
-      "version": "3.5.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.2.tgz",
-      "integrity": "sha512-dhHTWMI7kMx5whMQntl7Vr9C6BvV10lFXDAasnqnrMYhXVCzzk6IO9Fo2L75jXHT07WrOngL1WDXOp+yYS91Yg=="
-    },
     "boom": {
       "version": "4.3.1",
       "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
       "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "dev": true,
       "requires": {
         "hoek": "4.2.1"
       }
@@ -2935,6 +2449,7 @@
       "version": "1.3.0",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/boxen/-/boxen-1.3.0.tgz",
       "integrity": "sha1-VcbDmouljZxhrSLNh3Uy3rZlogs=",
+      "dev": true,
       "requires": {
         "ansi-align": "2.0.0",
         "camelcase": "4.1.0",
@@ -2948,12 +2463,14 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
           "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -2961,12 +2478,14 @@
         "camelcase": {
           "version": "4.1.0",
           "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/camelcase/-/camelcase-4.1.0.tgz",
-          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0="
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
         },
         "chalk": {
           "version": "2.4.1",
           "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
+          "dev": true,
           "requires": {
             "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
@@ -2976,12 +2495,14 @@
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -2991,6 +2512,7 @@
           "version": "4.0.0",
           "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
           }
@@ -2999,6 +2521,7 @@
           "version": "5.4.0",
           "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
+          "dev": true,
           "requires": {
             "has-flag": "3.0.0"
           }
@@ -3009,6 +2532,7 @@
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
       "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
+      "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
         "concat-map": "0.0.1"
@@ -3048,15 +2572,6 @@
         }
       }
     },
-    "browserslist": {
-      "version": "3.2.8",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/browserslist/-/browserslist-3.2.8.tgz",
-      "integrity": "sha1-sABTYdZHHw9ZUnl6dvyYXx+Xj8Y=",
-      "requires": {
-        "caniuse-lite": "1.0.30000856",
-        "electron-to-chromium": "1.3.50"
-      }
-    },
     "bser": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/bser/-/bser-2.0.0.tgz",
@@ -3072,28 +2587,6 @@
       "integrity": "sha1-M3dm2hWAEhD92VbCLpxokaudAzc=",
       "dev": true
     },
-    "buffer-alloc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-      "optional": true,
-      "requires": {
-        "buffer-alloc-unsafe": "1.1.0",
-        "buffer-fill": "1.0.0"
-      }
-    },
-    "buffer-alloc-unsafe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-      "optional": true
-    },
-    "buffer-fill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-      "optional": true
-    },
     "buffer-from": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
@@ -3103,12 +2596,8 @@
     "builtin-modules": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
-    },
-    "builtins": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-1.0.3.tgz",
-      "integrity": "sha1-y5T662HIaWRR2zZTThQi+U8K7og="
+      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+      "dev": true
     },
     "cache-base": {
       "version": "1.0.1",
@@ -3218,15 +2707,11 @@
         }
       }
     },
-    "caniuse-lite": {
-      "version": "1.0.30000856",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/caniuse-lite/-/caniuse-lite-1.0.30000856.tgz",
-      "integrity": "sha1-7MFpeBNabyGbE4mR62IAnSXujao="
-    },
     "capture-stack-trace": {
       "version": "1.0.0",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/capture-stack-trace/-/capture-stack-trace-1.0.0.tgz",
-      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0="
+      "integrity": "sha1-Sm+gc5nCa7pH8LJJa00PtAjFVQ0=",
+      "dev": true
     },
     "cardinal": {
       "version": "2.1.1",
@@ -3241,7 +2726,8 @@
     "caseless": {
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+      "dev": true
     },
     "center-align": {
       "version": "0.1.3",
@@ -3258,6 +2744,7 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
       "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
       "requires": {
         "ansi-styles": "2.2.1",
         "escape-string-regexp": "1.0.5",
@@ -3265,11 +2752,6 @@
         "strip-ansi": "3.0.1",
         "supports-color": "2.0.0"
       }
-    },
-    "chardet": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
-      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
     },
     "chokidar": {
       "version": "1.7.0",
@@ -3279,7 +2761,6 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.2.4",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -3288,16 +2769,11 @@
         "readdirp": "2.1.0"
       }
     },
-    "chownr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.0.1.tgz",
-      "integrity": "sha1-4qdQQqlVGQi+vSW4Uj1fl2nXkYE=",
-      "optional": true
-    },
     "ci-info": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.1.tgz",
-      "integrity": "sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ=="
+      "integrity": "sha512-vHDDF/bP9RYpTWtUhpJRhCFdvvp3iDWvEbuDbWgvjUrNGV1MXJrE0MPcwGtEled04m61iwdBLUIHZtDgzWS4ZQ==",
+      "dev": true
     },
     "class-utils": {
       "version": "0.3.6",
@@ -3337,7 +2813,8 @@
     "cli-boxes": {
       "version": "1.0.0",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/cli-boxes/-/cli-boxes-1.0.0.tgz",
-      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM="
+      "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
+      "dev": true
     },
     "cli-cursor": {
       "version": "1.0.2",
@@ -3384,32 +2861,8 @@
     "cli-width": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
-      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk="
-    },
-    "clipboardy": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-1.2.3.tgz",
-      "integrity": "sha512-2WNImOvCRe6r63Gk9pShfkwXsVtKCroMAevIbiae021mS850UkWPbevxsBz3tnvjZIEGvlwaqCPsw+4ulzNgJA==",
-      "requires": {
-        "arch": "2.1.1",
-        "execa": "0.8.0"
-      },
-      "dependencies": {
-        "execa": {
-          "version": "0.8.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
-          "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
-          "requires": {
-            "cross-spawn": "5.1.0",
-            "get-stream": "3.0.0",
-            "is-stream": "1.1.0",
-            "npm-run-path": "2.0.2",
-            "p-finally": "1.0.0",
-            "signal-exit": "3.0.2",
-            "strip-eof": "1.0.0"
-          }
-        }
-      }
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
     },
     "cliui": {
       "version": "2.1.0",
@@ -3444,12 +2897,14 @@
     "co": {
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+      "dev": true
     },
     "code-point-at": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "dev": true
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -3465,6 +2920,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.0.tgz",
       "integrity": "sha1-Gsz5fdc5uYO/mU1W/sj5WFNkG3o=",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -3472,7 +2928,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "colors": {
       "version": "1.1.2",
@@ -3484,6 +2941,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
       "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+      "dev": true,
       "requires": {
         "delayed-stream": "1.0.0"
       }
@@ -3558,12 +3016,14 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
     },
     "concat-stream": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+      "dev": true,
       "requires": {
         "inherits": "2.0.3",
         "readable-stream": "2.3.3",
@@ -3574,6 +3034,7 @@
       "version": "3.1.2",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/configstore/-/configstore-3.1.2.tgz",
       "integrity": "sha1-xvJd767vJt8S3TNBSwAf6BpUP48=",
+      "dev": true,
       "requires": {
         "dot-prop": "4.2.0",
         "graceful-fs": "4.1.11",
@@ -3587,16 +3048,12 @@
           "version": "4.2.0",
           "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/dot-prop/-/dot-prop-4.2.0.tgz",
           "integrity": "sha1-HxngwuGqDjJ5fEl5nyg3rGr2nFc=",
+          "dev": true,
           "requires": {
             "is-obj": "1.0.1"
           }
         }
       }
-    },
-    "console-control-strings": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
     },
     "content-type-parser": {
       "version": "1.0.2",
@@ -3674,7 +3131,8 @@
     "convert-source-map": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.0.tgz",
-      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU="
+      "integrity": "sha1-ms1whRxtXf3ZPZKC5e35SgP/RrU=",
+      "dev": true
     },
     "copy-descriptor": {
       "version": "0.1.1",
@@ -3685,12 +3143,14 @@
     "core-js": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cosmiconfig": {
       "version": "4.0.0",
@@ -3752,6 +3212,7 @@
       "version": "3.0.2",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
+      "dev": true,
       "requires": {
         "capture-stack-trace": "1.0.0"
       }
@@ -3778,6 +3239,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "dev": true,
       "requires": {
         "lru-cache": "4.1.1",
         "shebang-command": "1.2.0",
@@ -3788,6 +3250,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
       "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "dev": true,
       "requires": {
         "boom": "5.2.0"
       },
@@ -3796,6 +3259,7 @@
           "version": "5.2.0",
           "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
           "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
+          "dev": true,
           "requires": {
             "hoek": "4.2.1"
           }
@@ -3805,7 +3269,8 @@
     "crypto-random-string": {
       "version": "1.0.0",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
-      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
+      "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4=",
+      "dev": true
     },
     "cssom": {
       "version": "0.3.2",
@@ -3854,6 +3319,7 @@
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       },
@@ -3861,7 +3327,8 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
         }
       }
     },
@@ -3881,6 +3348,7 @@
       "version": "2.6.8",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
       "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "dev": true,
       "requires": {
         "ms": "2.0.0"
       }
@@ -3913,6 +3381,7 @@
       "version": "3.3.0",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "dev": true,
       "requires": {
         "mimic-response": "1.0.0"
       }
@@ -3932,7 +3401,8 @@
     "deep-extend": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.4.2.tgz",
-      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8="
+      "integrity": "sha1-SLaZwn4zS/ifEIkr5DL25MfTSn8=",
+      "dev": true
     },
     "deep-is": {
       "version": "0.1.3",
@@ -4021,12 +3491,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
-    },
-    "delegates": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "detect-file": {
       "version": "0.1.0",
@@ -4041,15 +3507,10 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
+      "dev": true,
       "requires": {
         "repeating": "2.0.1"
       }
-    },
-    "detect-libc": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-      "optional": true
     },
     "detect-newline": {
       "version": "2.1.0",
@@ -4144,21 +3605,18 @@
     "duplexer3": {
       "version": "0.1.4",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/duplexer3/-/duplexer3-0.1.4.tgz",
-      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
+      "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=",
+      "dev": true
     },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+      "dev": true,
       "optional": true,
       "requires": {
         "jsbn": "0.1.1"
       }
-    },
-    "electron-to-chromium": {
-      "version": "1.3.50",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/electron-to-chromium/-/electron-to-chromium-1.3.50.tgz",
-      "integrity": "sha1-dDi3b5K0G5GfP73TUPvQdX2s3fc="
     },
     "elegant-spinner": {
       "version": "1.0.1",
@@ -4170,6 +3628,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
       "requires": {
         "once": "1.4.0"
       }
@@ -4290,7 +3749,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.9.0",
@@ -4316,7 +3776,8 @@
     "esprima": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
-      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw=="
+      "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+      "dev": true
     },
     "estraverse": {
       "version": "4.2.0",
@@ -4333,7 +3794,8 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
     },
     "exec-sh": {
       "version": "0.2.1",
@@ -4348,6 +3810,7 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+      "dev": true,
       "requires": {
         "cross-spawn": "5.1.0",
         "get-stream": "3.0.0",
@@ -4387,12 +3850,6 @@
       "requires": {
         "fill-range": "2.2.3"
       }
-    },
-    "expand-template": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-1.1.1.tgz",
-      "integrity": "sha512-cebqLtV8KOZfw0UI8TEFWxtczxxC1jvyUvx6H4fyp1K1FN7A4Q+uggVUlOsI1K8AGU0rwOGqP8nCapdrw8CYQg==",
-      "optional": true
     },
     "expand-tilde": {
       "version": "1.2.2",
@@ -4437,12 +3894,14 @@
     "extend": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
-      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=",
+      "dev": true
     },
     "extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
+      "dev": true,
       "requires": {
         "is-extendable": "0.1.1"
       }
@@ -4470,7 +3929,8 @@
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
     },
     "eyes": {
       "version": "0.1.8",
@@ -4481,7 +3941,8 @@
     "fast-deep-equal": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
-      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
+      "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
+      "dev": true
     },
     "fast-glob": {
       "version": "2.2.2",
@@ -4833,7 +4294,8 @@
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -5007,12 +4469,14 @@
     "forever-agent": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+      "dev": true
     },
     "form-data": {
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "dev": true,
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.6",
@@ -5023,6 +4487,7 @@
           "version": "1.0.6",
           "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
           "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+          "dev": true,
           "requires": {
             "delayed-stream": "1.0.0"
           }
@@ -5048,16 +4513,11 @@
         "readable-stream": "2.3.3"
       }
     },
-    "fs-constants": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "optional": true
-    },
     "fs-exists-sync": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/fs-exists-sync/-/fs-exists-sync-0.1.0.tgz",
-      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0="
+      "integrity": "sha1-mC1ok6+RjnLQjeyehnP/K1qNat0=",
+      "dev": true
     },
     "fs-extra": {
       "version": "1.0.0",
@@ -5076,562 +4536,11 @@
       "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
       "dev": true
     },
-    "fsevents": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
-      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
-      "dev": true,
-      "optional": true,
-      "requires": {
-        "nan": "2.11.0",
-        "node-pre-gyp": "0.10.0"
-      },
-      "dependencies": {
-        "abbrev": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "ansi-regex": {
-          "version": "2.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "aproba": {
-          "version": "1.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "are-we-there-yet": {
-          "version": "1.1.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.6"
-          }
-        },
-        "balanced-match": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true
-        },
-        "brace-expansion": {
-          "version": "1.1.11",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
-        },
-        "chownr": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "code-point-at": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "concat-map": {
-          "version": "0.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "console-control-strings": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "debug": {
-          "version": "2.6.9",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
-        "deep-extend": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "delegates": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "detect-libc": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "fs-minipass": {
-          "version": "1.2.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "2.2.4"
-          }
-        },
-        "fs.realpath": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "gauge": {
-          "version": "2.7.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
-        },
-        "glob": {
-          "version": "7.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
-        },
-        "has-unicode": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "iconv-lite": {
-          "version": "0.4.21",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safer-buffer": "2.1.2"
-          }
-        },
-        "ignore-walk": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minimatch": "3.0.4"
-          }
-        },
-        "inflight": {
-          "version": "1.0.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
-        },
-        "inherits": {
-          "version": "2.0.3",
-          "bundled": true,
-          "dev": true
-        },
-        "ini": {
-          "version": "1.3.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
-        },
-        "isarray": {
-          "version": "1.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "minimatch": {
-          "version": "3.0.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.11"
-          }
-        },
-        "minimist": {
-          "version": "0.0.8",
-          "bundled": true,
-          "dev": true
-        },
-        "minipass": {
-          "version": "2.2.4",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
-          }
-        },
-        "minizlib": {
-          "version": "1.1.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "minipass": "2.2.4"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
-        },
-        "ms": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "nan": {
-          "version": "2.11.0",
-          "resolved": "https://registry.npmjs.org/nan/-/nan-2.11.0.tgz",
-          "integrity": "sha512-F4miItu2rGnV2ySkXOQoA8FKz/SR2Q2sWP0sbTxNxz/tuokeC8WxOhPMcwi0qIyGtVn/rrSeLbvVkznqCdwYnw==",
-          "dev": true,
-          "optional": true
-        },
-        "needle": {
-          "version": "2.2.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.6.9",
-            "iconv-lite": "0.4.21",
-            "sax": "1.2.4"
-          }
-        },
-        "node-pre-gyp": {
-          "version": "0.10.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "needle": "2.2.0",
-            "nopt": "4.0.1",
-            "npm-packlist": "1.1.10",
-            "npmlog": "4.1.2",
-            "rc": "1.2.7",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "4.4.1"
-          }
-        },
-        "nopt": {
-          "version": "4.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
-          }
-        },
-        "npm-bundled": {
-          "version": "1.0.3",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "npm-packlist": {
-          "version": "1.1.10",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "ignore-walk": "3.0.1",
-            "npm-bundled": "1.0.3"
-          }
-        },
-        "npmlog": {
-          "version": "4.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
-        },
-        "number-is-nan": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true
-        },
-        "object-assign": {
-          "version": "4.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "once": {
-          "version": "1.4.0",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
-        },
-        "os-homedir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "os-tmpdir": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "osenv": {
-          "version": "0.1.5",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "path-is-absolute": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "process-nextick-args": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "rc": {
-          "version": "1.2.7",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "deep-extend": "0.5.1",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
-          "dependencies": {
-            "minimist": {
-              "version": "1.2.0",
-              "bundled": true,
-              "dev": true,
-              "optional": true
-            }
-          }
-        },
-        "readable-stream": {
-          "version": "2.3.6",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.1.1",
-            "util-deprecate": "1.0.2"
-          }
-        },
-        "rimraf": {
-          "version": "2.6.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "bundled": true,
-          "dev": true
-        },
-        "safer-buffer": {
-          "version": "2.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "sax": {
-          "version": "1.2.4",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "semver": {
-          "version": "5.5.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "set-blocking": {
-          "version": "2.0.0",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "signal-exit": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.1.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "strip-json-comments": {
-          "version": "2.0.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "tar": {
-          "version": "4.4.1",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "chownr": "1.0.1",
-            "fs-minipass": "1.2.5",
-            "minipass": "2.2.4",
-            "minizlib": "1.1.0",
-            "mkdirp": "0.5.1",
-            "safe-buffer": "5.1.1",
-            "yallist": "3.0.2"
-          }
-        },
-        "util-deprecate": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true
-        },
-        "wide-align": {
-          "version": "1.1.2",
-          "bundled": true,
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
-        },
-        "wrappy": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true
-        },
-        "yallist": {
-          "version": "3.0.2",
-          "bundled": true,
-          "dev": true
-        }
-      }
-    },
     "function-bind": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
       "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
       "dev": true
-    },
-    "gauge": {
-      "version": "2.7.4",
-      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
-      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-      "requires": {
-        "aproba": "1.2.0",
-        "console-control-strings": "1.1.0",
-        "has-unicode": "2.0.1",
-        "object-assign": "4.1.1",
-        "signal-exit": "3.0.2",
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1",
-        "wide-align": "1.1.2"
-      }
     },
     "get-caller-file": {
       "version": "1.0.2",
@@ -5648,7 +4557,8 @@
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+      "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+      "dev": true
     },
     "get-value": {
       "version": "2.0.6",
@@ -5660,6 +4570,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0"
       },
@@ -5667,18 +4578,9 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
         }
-      }
-    },
-    "git-config-path": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/git-config-path/-/git-config-path-1.0.1.tgz",
-      "integrity": "sha1-bTP37WPbDQ4RgTFQO6s6ykfVRmQ=",
-      "requires": {
-        "extend-shallow": "2.0.1",
-        "fs-exists-sync": "0.1.0",
-        "homedir-polyfill": "1.0.1"
       }
     },
     "git-log-parser": {
@@ -5724,22 +4626,6 @@
       "requires": {
         "git-up": "2.0.10"
       }
-    },
-    "github": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/github/-/github-0.1.16.tgz",
-      "integrity": "sha1-iV0qhbD+t5gNiawM5PRNyqA/F7U="
-    },
-    "github-from-package": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
-      "optional": true
-    },
-    "github-url-from-git": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/github-url-from-git/-/github-url-from-git-1.5.0.tgz",
-      "integrity": "sha1-+YX+3MCpqledyI16/waNVcxiUaA="
     },
     "glob": {
       "version": "7.1.1",
@@ -5793,6 +4679,7 @@
       "version": "0.1.1",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/global-dirs/-/global-dirs-0.1.1.tgz",
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
+      "dev": true,
       "requires": {
         "ini": "1.3.4"
       }
@@ -5822,7 +4709,8 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+      "dev": true
     },
     "globby": {
       "version": "8.0.1",
@@ -5903,7 +4791,8 @@
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "dev": true
     },
     "growly": {
       "version": "1.3.0",
@@ -5943,12 +4832,14 @@
     "har-schema": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+      "dev": true
     },
     "har-validator": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "dev": true,
       "requires": {
         "ajv": "5.5.2",
         "har-schema": "2.0.0"
@@ -5967,6 +4858,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
       "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -5974,12 +4866,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-    },
-    "has-unicode": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -6045,6 +4933,7 @@
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
       "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "dev": true,
       "requires": {
         "boom": "4.3.1",
         "cryptiles": "3.1.2",
@@ -6061,12 +4950,14 @@
     "hoek": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA=="
+      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+      "dev": true
     },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
+      "dev": true,
       "requires": {
         "os-homedir": "1.0.2",
         "os-tmpdir": "1.0.2"
@@ -6076,6 +4967,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
+      "dev": true,
       "requires": {
         "parse-passwd": "1.0.0"
       }
@@ -6089,7 +4981,8 @@
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
-      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg=="
+      "integrity": "sha512-pNgbURSuab90KbTqvRPsseaTxOJCZBD0a7t+haSN33piP9cCM4l0CqdzAif2hUqm716UovKB2ROmiabGAKVXyg==",
+      "dev": true
     },
     "html-encoding-sniffer": {
       "version": "1.0.2",
@@ -6131,6 +5024,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
@@ -6207,7 +5101,8 @@
     "import-lazy": {
       "version": "2.1.0",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/import-lazy/-/import-lazy-2.1.0.tgz",
-      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM="
+      "integrity": "sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=",
+      "dev": true
     },
     "import-local": {
       "version": "1.0.0",
@@ -6222,7 +5117,8 @@
     "imurmurhash": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
     },
     "indent-string": {
       "version": "2.1.0",
@@ -6246,12 +5142,14 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
     },
     "ini": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz",
-      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4="
+      "integrity": "sha1-BTfLedr1m1mhpRff9wbIbsA5Fi4=",
+      "dev": true
     },
     "inquirer": {
       "version": "1.2.3",
@@ -6295,6 +5193,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.2.tgz",
       "integrity": "sha1-nh9WrArNtr8wMwbzOL47IErmA2A=",
+      "dev": true,
       "requires": {
         "loose-envify": "1.3.1"
       }
@@ -6339,6 +5238,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+      "dev": true,
       "requires": {
         "builtin-modules": "1.1.1"
       }
@@ -6353,6 +5253,7 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
       "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "dev": true,
       "requires": {
         "ci-info": "1.1.1"
       }
@@ -6415,7 +5316,8 @@
     "is-extendable": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik="
+      "integrity": "sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=",
+      "dev": true
     },
     "is-extglob": {
       "version": "1.0.0",
@@ -6427,6 +5329,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+      "dev": true,
       "requires": {
         "number-is-nan": "1.0.1"
       }
@@ -6435,6 +5338,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
       "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "dev": true,
       "requires": {
         "number-is-nan": "1.0.1"
       }
@@ -6458,6 +5362,7 @@
       "version": "0.1.0",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
+      "dev": true,
       "requires": {
         "global-dirs": "0.1.1",
         "is-path-inside": "1.0.1"
@@ -6472,7 +5377,8 @@
     "is-npm": {
       "version": "1.0.0",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/is-npm/-/is-npm-1.0.0.tgz",
-      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ="
+      "integrity": "sha1-8vtjpl5JBbQGyGBydloaTceTufQ=",
+      "dev": true
     },
     "is-number": {
       "version": "2.1.0",
@@ -6486,7 +5392,8 @@
     "is-obj": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
-      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8="
+      "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
+      "dev": true
     },
     "is-observable": {
       "version": "0.2.0",
@@ -6501,6 +5408,7 @@
       "version": "1.0.1",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+      "dev": true,
       "requires": {
         "path-is-inside": "1.0.2"
       }
@@ -6543,12 +5451,14 @@
     "is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
-      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o="
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
     },
     "is-redirect": {
       "version": "1.0.0",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/is-redirect/-/is-redirect-1.0.0.tgz",
-      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ="
+      "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
     },
     "is-regex": {
       "version": "1.0.4",
@@ -6568,7 +5478,8 @@
     "is-retry-allowed": {
       "version": "1.1.0",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/is-retry-allowed/-/is-retry-allowed-1.1.0.tgz",
-      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ="
+      "integrity": "sha1-EaBgVotnM5REAz0BJaYaINVk+zQ=",
+      "dev": true
     },
     "is-ssh": {
       "version": "1.3.0",
@@ -6582,7 +5493,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-subset": {
       "version": "0.1.1",
@@ -6608,7 +5520,8 @@
     "is-typedarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+      "dev": true
     },
     "is-utf8": {
       "version": "0.2.1",
@@ -6625,12 +5538,14 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
     },
     "isobject": {
       "version": "2.1.0",
@@ -6644,7 +5559,8 @@
     "isstream": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+      "dev": true
     },
     "issue-parser": {
       "version": "3.0.0",
@@ -8219,12 +7135,14 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+      "dev": true,
       "requires": {
         "argparse": "1.0.9",
         "esprima": "4.0.0"
@@ -8234,6 +7152,7 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "dev": true,
       "optional": true
     },
     "jsdom": {
@@ -8273,7 +7192,8 @@
     "jsesc": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-1.3.0.tgz",
-      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s="
+      "integrity": "sha1-RsP+yMGJKxKwgz25vHYiF226s0s=",
+      "dev": true
     },
     "json-buffer": {
       "version": "3.0.0",
@@ -8290,12 +7210,14 @@
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+      "dev": true
     },
     "json-schema-traverse": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+      "dev": true
     },
     "json-stable-stringify": {
       "version": "1.0.1",
@@ -8309,12 +7231,14 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true
     },
     "jsonfile": {
       "version": "2.4.0",
@@ -8341,6 +7265,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
       "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "extsprintf": "1.3.0",
@@ -8351,18 +7276,9 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
         }
-      }
-    },
-    "keytar": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/keytar/-/keytar-4.2.1.tgz",
-      "integrity": "sha1-igamV3/fY3PgqmsRInfmPex3/RI=",
-      "optional": true,
-      "requires": {
-        "nan": "2.8.0",
-        "prebuild-install": "2.5.3"
       }
     },
     "keyv": {
@@ -8396,6 +7312,7 @@
       "version": "3.1.0",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/latest-version/-/latest-version-3.1.0.tgz",
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
+      "dev": true,
       "requires": {
         "package-json": "4.0.1"
       }
@@ -8683,7 +7600,8 @@
     "lodash": {
       "version": "4.17.2",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.2.tgz",
-      "integrity": "sha1-NKMFW6vgTOQkZ7YH1wAHLH/2v0I="
+      "integrity": "sha1-NKMFW6vgTOQkZ7YH1wAHLH/2v0I=",
+      "dev": true
     },
     "lodash.assign": {
       "version": "4.2.0",
@@ -8811,6 +7729,7 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
       "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true,
       "requires": {
         "js-tokens": "3.0.2"
       }
@@ -8828,12 +7747,14 @@
     "lowercase-keys": {
       "version": "1.0.1",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
-      "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8="
+      "integrity": "sha1-b54wtHCE2XGnyCD/FabFFnt0wm8=",
+      "dev": true
     },
     "lru-cache": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
+      "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
@@ -8852,6 +7773,7 @@
       "version": "1.3.0",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/make-dir/-/make-dir-1.3.0.tgz",
       "integrity": "sha1-ecEDO4BRW9bSTsmTPoYMp17ifww=",
+      "dev": true,
       "requires": {
         "pify": "3.0.0"
       }
@@ -9079,12 +8001,14 @@
     "mime-db": {
       "version": "1.30.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
-      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE=",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.17",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
       "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+      "dev": true,
       "requires": {
         "mime-db": "1.30.0"
       }
@@ -9092,17 +8016,20 @@
     "mimic-fn": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
+      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg=",
+      "dev": true
     },
     "mimic-response": {
       "version": "1.0.0",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/mimic-response/-/mimic-response-1.0.0.tgz",
-      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4="
+      "integrity": "sha1-3z02Uqc/3ta5sLJBRub9BSNTRY4=",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
       "requires": {
         "brace-expansion": "1.1.8"
       }
@@ -9110,7 +8037,8 @@
     "minimist": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+      "dev": true
     },
     "minimist-options": {
       "version": "3.0.2",
@@ -9147,6 +8075,7 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.8"
       },
@@ -9154,7 +8083,8 @@
         "minimist": {
           "version": "0.0.8",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
         }
       }
     },
@@ -9167,19 +8097,14 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.6.tgz",
       "integrity": "sha1-SJYrGeFp/R38JAs/HnMXYnu8R9s=",
       "dev": true
-    },
-    "nan": {
-      "version": "2.8.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.8.0.tgz",
-      "integrity": "sha1-7XFfP+neArV6XmJS2QqWZ14fCFo=",
-      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",
@@ -9269,15 +8194,6 @@
       "integrity": "sha1-2Tli9sUvLBVYwPvabVEoGfHv4cQ=",
       "dev": true
     },
-    "node-abi": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.4.3.tgz",
-      "integrity": "sha512-b656V5C0628gOOA2kwcpNA/bxdlqYF9FvxJ+qqVX0ctdXNVZpS8J6xEUYir3WAKc7U0BH/NRlSpNbGsy+azjeg==",
-      "optional": true,
-      "requires": {
-        "semver": "5.4.1"
-      }
-    },
     "node-emoji": {
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-1.8.1.tgz",
@@ -9314,25 +8230,11 @@
         "semver": "5.4.1"
       }
     },
-    "noop-logger": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
-      "optional": true
-    },
-    "nopt": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/nopt/-/nopt-4.0.1.tgz",
-      "integrity": "sha1-0NRoWv1UFRk8jHUFYC0NF81kR00=",
-      "requires": {
-        "abbrev": "1.1.1",
-        "osenv": "0.1.5"
-      }
-    },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+      "dev": true,
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
@@ -9359,6 +8261,7 @@
       "version": "6.4.1",
       "resolved": "https://registry.npmjs.org/npm/-/npm-6.4.1.tgz",
       "integrity": "sha512-mXJL1NTVU136PtuopXCUQaNWuHlXCTp4McwlSW8S9/Aj8OEPAlSBgo8og7kJ01MjCDrkmqFQTvN5tTEhBMhXQg==",
+      "dev": true,
       "requires": {
         "JSONStream": "1.3.4",
         "abbrev": "1.1.1",
@@ -9483,6 +8386,7 @@
         "JSONStream": {
           "version": "1.3.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "jsonparse": "1.3.1",
             "through": "2.3.8"
@@ -9490,11 +8394,13 @@
         },
         "abbrev": {
           "version": "1.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "agent-base": {
           "version": "4.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "es6-promisify": "5.0.0"
           }
@@ -9502,6 +8408,7 @@
         "agentkeepalive": {
           "version": "3.4.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "humanize-ms": "1.2.1"
           }
@@ -9509,6 +8416,7 @@
         "ajv": {
           "version": "5.5.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "co": "4.6.0",
             "fast-deep-equal": "1.1.0",
@@ -9519,40 +8427,48 @@
         "ansi-align": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "string-width": "2.1.1"
           }
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ansi-styles": {
           "version": "3.2.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "color-convert": "1.9.1"
           }
         },
         "ansicolors": {
           "version": "0.3.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ansistyles": {
           "version": "0.1.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "archy": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "are-we-there-yet": {
           "version": "1.1.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "delegates": "1.0.0",
             "readable-stream": "2.3.6"
@@ -9560,38 +8476,46 @@
         },
         "asap": {
           "version": "2.0.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "asn1": {
           "version": "0.2.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "safer-buffer": "2.1.2"
           }
         },
         "assert-plus": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "asynckit": {
           "version": "0.4.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "aws-sign2": {
           "version": "0.7.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "aws4": {
           "version": "1.8.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "bcrypt-pbkdf": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "tweetnacl": "0.14.5"
@@ -9600,6 +8524,7 @@
         "bin-links": {
           "version": "1.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "bluebird": "3.5.1",
             "cmd-shim": "2.0.2",
@@ -9611,17 +8536,20 @@
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
+          "dev": true,
           "requires": {
             "inherits": "2.0.3"
           }
         },
         "bluebird": {
           "version": "3.5.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "boxen": {
           "version": "1.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ansi-align": "2.0.0",
             "camelcase": "4.1.0",
@@ -9635,6 +8563,7 @@
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "dev": true,
           "requires": {
             "balanced-match": "1.0.0",
             "concat-map": "0.0.1"
@@ -9642,27 +8571,33 @@
         },
         "buffer-from": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "builtin-modules": {
           "version": "1.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "builtins": {
           "version": "1.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "byline": {
           "version": "5.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "byte-size": {
           "version": "4.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "cacache": {
           "version": "11.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "bluebird": "3.5.1",
             "chownr": "1.0.1",
@@ -9682,23 +8617,28 @@
         },
         "call-limit": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "camelcase": {
           "version": "4.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "capture-stack-trace": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "caseless": {
           "version": "0.12.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "chalk": {
           "version": "2.4.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
@@ -9707,26 +8647,31 @@
         },
         "chownr": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ci-info": {
           "version": "1.4.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "cidr-regex": {
           "version": "2.0.9",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ip-regex": "2.1.0"
           }
         },
         "cli-boxes": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "cli-columns": {
           "version": "3.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "string-width": "2.1.1",
             "strip-ansi": "3.0.1"
@@ -9735,6 +8680,7 @@
         "cli-table3": {
           "version": "0.5.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "colors": "1.1.2",
             "object-assign": "4.1.1",
@@ -9744,6 +8690,7 @@
         "cliui": {
           "version": "4.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "string-width": "2.1.1",
             "strip-ansi": "4.0.0",
@@ -9752,11 +8699,13 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "ansi-regex": "3.0.0"
               }
@@ -9765,11 +8714,13 @@
         },
         "clone": {
           "version": "1.0.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "cmd-shim": {
           "version": "2.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "mkdirp": "0.5.1"
@@ -9777,31 +8728,37 @@
         },
         "co": {
           "version": "4.6.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "color-convert": {
           "version": "1.9.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "color-name": "1.1.3"
           }
         },
         "color-name": {
           "version": "1.1.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "colors": {
           "version": "1.1.2",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "columnify": {
           "version": "1.5.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "strip-ansi": "3.0.1",
             "wcwidth": "1.0.1"
@@ -9810,17 +8767,20 @@
         "combined-stream": {
           "version": "1.0.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "delayed-stream": "1.0.0"
           }
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "concat-stream": {
           "version": "1.6.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "buffer-from": "1.0.0",
             "inherits": "2.0.3",
@@ -9831,6 +8791,7 @@
         "config-chain": {
           "version": "1.1.11",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ini": "1.3.5",
             "proto-list": "1.2.4"
@@ -9839,6 +8800,7 @@
         "configstore": {
           "version": "3.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "dot-prop": "4.2.0",
             "graceful-fs": "4.1.11",
@@ -9850,11 +8812,13 @@
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "copy-concurrently": {
           "version": "1.0.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "1.2.0",
             "fs-write-stream-atomic": "1.0.10",
@@ -9866,17 +8830,20 @@
           "dependencies": {
             "iferr": {
               "version": "0.1.5",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "core-util-is": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "create-error-class": {
           "version": "3.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "capture-stack-trace": "1.0.0"
           }
@@ -9884,6 +8851,7 @@
         "cross-spawn": {
           "version": "5.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "lru-cache": "4.1.3",
             "shebang-command": "1.2.0",
@@ -9892,15 +8860,18 @@
         },
         "crypto-random-string": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "cyclist": {
           "version": "0.2.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "dashdash": {
           "version": "1.14.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "assert-plus": "1.0.0"
           }
@@ -9908,58 +8879,70 @@
         "debug": {
           "version": "3.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           },
           "dependencies": {
             "ms": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "debuglog": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "decamelize": {
           "version": "1.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "decode-uri-component": {
           "version": "0.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "deep-extend": {
           "version": "0.5.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "defaults": {
           "version": "1.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "clone": "1.0.4"
           }
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "delegates": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "detect-indent": {
           "version": "5.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "detect-newline": {
           "version": "2.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "dezalgo": {
           "version": "1.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "asap": "2.0.6",
             "wrappy": "1.0.2"
@@ -9968,21 +8951,25 @@
         "dot-prop": {
           "version": "4.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-obj": "1.0.1"
           }
         },
         "dotenv": {
           "version": "5.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "duplexer3": {
           "version": "0.1.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "duplexify": {
           "version": "3.6.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "end-of-stream": "1.4.1",
             "inherits": "2.0.3",
@@ -9993,6 +8980,7 @@
         "ecc-jsbn": {
           "version": "0.1.2",
           "bundled": true,
+          "dev": true,
           "optional": true,
           "requires": {
             "jsbn": "0.1.1",
@@ -10001,11 +8989,13 @@
         },
         "editor": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "encoding": {
           "version": "0.1.12",
           "bundled": true,
+          "dev": true,
           "requires": {
             "iconv-lite": "0.4.23"
           }
@@ -10013,39 +9003,46 @@
         "end-of-stream": {
           "version": "1.4.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "once": "1.4.0"
           }
         },
         "err-code": {
           "version": "1.1.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "errno": {
           "version": "0.1.7",
           "bundled": true,
+          "dev": true,
           "requires": {
             "prr": "1.0.1"
           }
         },
         "es6-promise": {
           "version": "4.2.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "es6-promisify": {
           "version": "5.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "es6-promise": "4.2.4"
           }
         },
         "escape-string-regexp": {
           "version": "1.0.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "execa": {
           "version": "0.7.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cross-spawn": "5.1.0",
             "get-stream": "3.0.0",
@@ -10058,31 +9055,38 @@
         },
         "extend": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "extsprintf": {
           "version": "1.3.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "fast-deep-equal": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "figgy-pudding": {
           "version": "3.4.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "find-npm-prefix": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "find-up": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "locate-path": "2.0.0"
           }
@@ -10090,6 +9094,7 @@
         "flush-write-stream": {
           "version": "1.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "inherits": "2.0.3",
             "readable-stream": "2.3.6"
@@ -10097,11 +9102,13 @@
         },
         "forever-agent": {
           "version": "0.6.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "form-data": {
           "version": "2.3.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "asynckit": "0.4.0",
             "combined-stream": "1.0.6",
@@ -10111,6 +9118,7 @@
         "from2": {
           "version": "2.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "inherits": "2.0.3",
             "readable-stream": "2.3.6"
@@ -10119,6 +9127,7 @@
         "fs-minipass": {
           "version": "1.2.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minipass": "2.3.3"
           }
@@ -10126,6 +9135,7 @@
         "fs-vacuum": {
           "version": "1.2.10",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "path-is-inside": "1.0.2",
@@ -10135,6 +9145,7 @@
         "fs-write-stream-atomic": {
           "version": "1.0.10",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "iferr": "0.1.5",
@@ -10144,17 +9155,20 @@
           "dependencies": {
             "iferr": {
               "version": "0.1.5",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "fstream": {
           "version": "1.0.11",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "inherits": "2.0.3",
@@ -10165,6 +9179,7 @@
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "1.2.0",
             "console-control-strings": "1.1.0",
@@ -10179,6 +9194,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "code-point-at": "1.1.0",
                 "is-fullwidth-code-point": "1.0.0",
@@ -10189,11 +9205,13 @@
         },
         "genfun": {
           "version": "4.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "gentle-fs": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "1.2.0",
             "fs-vacuum": "1.2.10",
@@ -10207,21 +9225,25 @@
           "dependencies": {
             "iferr": {
               "version": "0.1.5",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "get-caller-file": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "get-stream": {
           "version": "3.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "getpass": {
           "version": "0.1.7",
           "bundled": true,
+          "dev": true,
           "requires": {
             "assert-plus": "1.0.0"
           }
@@ -10229,6 +9251,7 @@
         "glob": {
           "version": "7.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "fs.realpath": "1.0.0",
             "inflight": "1.0.6",
@@ -10241,6 +9264,7 @@
         "global-dirs": {
           "version": "0.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ini": "1.3.5"
           }
@@ -10248,6 +9272,7 @@
         "got": {
           "version": "6.7.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "create-error-class": "3.0.2",
             "duplexer3": "0.1.4",
@@ -10264,15 +9289,18 @@
         },
         "graceful-fs": {
           "version": "4.1.11",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "har-schema": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "har-validator": {
           "version": "5.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ajv": "5.5.2",
             "har-schema": "2.0.0"
@@ -10280,23 +9308,28 @@
         },
         "has-flag": {
           "version": "3.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "has-unicode": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "hosted-git-info": {
           "version": "2.7.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "http-cache-semantics": {
           "version": "3.8.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "http-proxy-agent": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "agent-base": "4.2.0",
             "debug": "3.1.0"
@@ -10305,6 +9338,7 @@
         "http-signature": {
           "version": "1.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "assert-plus": "1.0.0",
             "jsprim": "1.4.1",
@@ -10314,6 +9348,7 @@
         "https-proxy-agent": {
           "version": "2.2.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "agent-base": "4.2.0",
             "debug": "3.1.0"
@@ -10322,6 +9357,7 @@
         "humanize-ms": {
           "version": "1.2.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ms": "2.1.1"
           }
@@ -10329,32 +9365,38 @@
         "iconv-lite": {
           "version": "0.4.23",
           "bundled": true,
+          "dev": true,
           "requires": {
             "safer-buffer": "2.1.2"
           }
         },
         "iferr": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ignore-walk": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minimatch": "3.0.4"
           }
         },
         "import-lazy": {
           "version": "2.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "imurmurhash": {
           "version": "0.1.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "once": "1.4.0",
             "wrappy": "1.0.2"
@@ -10362,15 +9404,18 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "init-package-json": {
           "version": "1.10.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "glob": "7.1.2",
             "npm-package-arg": "6.1.0",
@@ -10384,19 +9429,23 @@
         },
         "invert-kv": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ip": {
           "version": "1.1.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "ip-regex": {
           "version": "2.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-builtin-module": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "builtin-modules": "1.1.1"
           }
@@ -10404,6 +9453,7 @@
         "is-ci": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ci-info": "1.4.0"
           }
@@ -10411,6 +9461,7 @@
         "is-cidr": {
           "version": "2.0.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cidr-regex": "2.0.9"
           }
@@ -10418,6 +9469,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "number-is-nan": "1.0.1"
           }
@@ -10425,6 +9477,7 @@
         "is-installed-globally": {
           "version": "0.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "global-dirs": "0.1.1",
             "is-path-inside": "1.0.1"
@@ -10432,75 +9485,92 @@
         },
         "is-npm": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-obj": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-path-inside": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "path-is-inside": "1.0.2"
           }
         },
         "is-redirect": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-retry-allowed": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-stream": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "isarray": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "isexe": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "isstream": {
           "version": "0.1.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "jsbn": {
           "version": "0.1.1",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "json-parse-better-errors": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "json-schema-traverse": {
           "version": "0.3.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "jsonparse": {
           "version": "1.3.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "jsprim": {
           "version": "1.4.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "assert-plus": "1.0.0",
             "extsprintf": "1.3.0",
@@ -10511,17 +9581,20 @@
         "latest-version": {
           "version": "3.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "package-json": "4.0.1"
           }
         },
         "lazy-property": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lcid": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "invert-kv": "1.0.0"
           }
@@ -10529,6 +9602,7 @@
         "libcipm": {
           "version": "2.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "bin-links": "1.1.2",
             "bluebird": "3.5.1",
@@ -10549,6 +9623,7 @@
         "libnpmhook": {
           "version": "4.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "figgy-pudding": "3.4.1",
             "npm-registry-fetch": "3.1.1"
@@ -10557,6 +9632,7 @@
             "npm-registry-fetch": {
               "version": "3.1.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "bluebird": "3.5.1",
                 "figgy-pudding": "3.4.1",
@@ -10570,6 +9646,7 @@
         "libnpx": {
           "version": "10.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "dotenv": "5.0.1",
             "npm-package-arg": "6.1.0",
@@ -10584,6 +9661,7 @@
         "locate-path": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "p-locate": "2.0.0",
             "path-exists": "3.0.0"
@@ -10592,6 +9670,7 @@
         "lock-verify": {
           "version": "2.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "npm-package-arg": "6.1.0",
             "semver": "5.5.0"
@@ -10600,17 +9679,20 @@
         "lockfile": {
           "version": "1.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "signal-exit": "3.0.2"
           }
         },
         "lodash._baseindexof": {
           "version": "3.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash._baseuniq": {
           "version": "4.6.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "lodash._createset": "4.0.3",
             "lodash._root": "3.0.1"
@@ -10618,58 +9700,71 @@
         },
         "lodash._bindcallback": {
           "version": "3.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash._cacheindexof": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash._createcache": {
           "version": "3.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "lodash._getnative": "3.9.1"
           }
         },
         "lodash._createset": {
           "version": "4.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash._getnative": {
           "version": "3.9.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash._root": {
           "version": "3.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash.clonedeep": {
           "version": "4.5.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash.restparam": {
           "version": "3.6.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash.union": {
           "version": "4.6.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash.uniq": {
           "version": "4.5.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lodash.without": {
           "version": "4.4.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lowercase-keys": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "lru-cache": {
           "version": "4.1.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "pseudomap": "1.0.2",
             "yallist": "2.1.2"
@@ -10678,6 +9773,7 @@
         "make-dir": {
           "version": "1.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "pify": "3.0.0"
           }
@@ -10685,6 +9781,7 @@
         "make-fetch-happen": {
           "version": "4.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "agentkeepalive": "3.4.1",
             "cacache": "11.2.0",
@@ -10701,44 +9798,52 @@
         },
         "meant": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "mem": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "mimic-fn": "1.2.0"
           }
         },
         "mime-db": {
           "version": "1.35.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "mime-types": {
           "version": "2.1.19",
           "bundled": true,
+          "dev": true,
           "requires": {
             "mime-db": "1.35.0"
           }
         },
         "mimic-fn": {
           "version": "1.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "brace-expansion": "1.1.11"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "minipass": {
           "version": "2.3.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "safe-buffer": "5.1.2",
             "yallist": "3.0.2"
@@ -10746,13 +9851,15 @@
           "dependencies": {
             "yallist": {
               "version": "3.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "minizlib": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minipass": "2.3.3"
           }
@@ -10760,6 +9867,7 @@
         "mississippi": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "concat-stream": "1.6.2",
             "duplexify": "3.6.0",
@@ -10776,6 +9884,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -10783,6 +9892,7 @@
         "move-concurrently": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "1.2.0",
             "copy-concurrently": "1.0.5",
@@ -10794,15 +9904,18 @@
         },
         "ms": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "mute-stream": {
           "version": "0.0.7",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "node-fetch-npm": {
           "version": "2.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "encoding": "0.1.12",
             "json-parse-better-errors": "1.0.2",
@@ -10812,6 +9925,7 @@
         "node-gyp": {
           "version": "3.8.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "fstream": "1.0.11",
             "glob": "7.1.2",
@@ -10830,17 +9944,20 @@
             "nopt": {
               "version": "3.0.6",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "abbrev": "1.1.1"
               }
             },
             "semver": {
               "version": "5.3.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "tar": {
               "version": "2.2.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "block-stream": "0.0.9",
                 "fstream": "1.0.11",
@@ -10852,6 +9969,7 @@
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "abbrev": "1.1.1",
             "osenv": "0.1.5"
@@ -10860,6 +9978,7 @@
         "normalize-package-data": {
           "version": "2.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "hosted-git-info": "2.7.1",
             "is-builtin-module": "1.0.0",
@@ -10870,6 +9989,7 @@
         "npm-audit-report": {
           "version": "1.3.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cli-table3": "0.5.0",
             "console-control-strings": "1.1.0"
@@ -10877,15 +9997,18 @@
         },
         "npm-bundled": {
           "version": "1.0.5",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "npm-cache-filename": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "npm-install-checks": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "semver": "5.5.0"
           }
@@ -10893,6 +10016,7 @@
         "npm-lifecycle": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "byline": "5.0.0",
             "graceful-fs": "4.1.11",
@@ -10906,11 +10030,13 @@
         },
         "npm-logical-tree": {
           "version": "1.2.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "npm-package-arg": {
           "version": "6.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "hosted-git-info": "2.7.1",
             "osenv": "0.1.5",
@@ -10921,6 +10047,7 @@
         "npm-packlist": {
           "version": "1.1.11",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ignore-walk": "3.0.1",
             "npm-bundled": "1.0.5"
@@ -10929,6 +10056,7 @@
         "npm-pick-manifest": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "npm-package-arg": "6.1.0",
             "semver": "5.5.0"
@@ -10937,6 +10065,7 @@
         "npm-profile": {
           "version": "3.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "1.2.0",
             "make-fetch-happen": "4.0.1"
@@ -10945,6 +10074,7 @@
         "npm-registry-client": {
           "version": "8.6.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "concat-stream": "1.6.2",
             "graceful-fs": "4.1.11",
@@ -10962,11 +10092,13 @@
           "dependencies": {
             "retry": {
               "version": "0.10.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "ssri": {
               "version": "5.3.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "safe-buffer": "5.1.2"
               }
@@ -10976,6 +10108,7 @@
         "npm-registry-fetch": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "bluebird": "3.5.1",
             "figgy-pudding": "2.0.1",
@@ -10988,6 +10121,7 @@
             "cacache": {
               "version": "10.0.4",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "bluebird": "3.5.1",
                 "chownr": "1.0.1",
@@ -11007,6 +10141,7 @@
                 "mississippi": {
                   "version": "2.0.0",
                   "bundled": true,
+                  "dev": true,
                   "requires": {
                     "concat-stream": "1.6.2",
                     "duplexify": "3.6.0",
@@ -11024,11 +10159,13 @@
             },
             "figgy-pudding": {
               "version": "2.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "make-fetch-happen": {
               "version": "3.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "agentkeepalive": "3.4.1",
                 "cacache": "10.0.4",
@@ -11046,6 +10183,7 @@
             "pump": {
               "version": "2.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "end-of-stream": "1.4.1",
                 "once": "1.4.0"
@@ -11053,11 +10191,13 @@
             },
             "smart-buffer": {
               "version": "1.1.15",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "socks": {
               "version": "1.1.10",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "ip": "1.1.5",
                 "smart-buffer": "1.1.15"
@@ -11066,6 +10206,7 @@
             "socks-proxy-agent": {
               "version": "3.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "agent-base": "4.2.0",
                 "socks": "1.1.10"
@@ -11074,6 +10215,7 @@
             "ssri": {
               "version": "5.3.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "safe-buffer": "5.1.2"
               }
@@ -11083,17 +10225,20 @@
         "npm-run-path": {
           "version": "2.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "path-key": "2.0.1"
           }
         },
         "npm-user-validate": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "are-we-there-yet": "1.1.4",
             "console-control-strings": "1.1.0",
@@ -11103,34 +10248,41 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "oauth-sign": {
           "version": "0.9.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "once": {
           "version": "1.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "wrappy": "1.0.2"
           }
         },
         "opener": {
           "version": "1.5.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "os-homedir": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "os-locale": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "execa": "0.7.0",
             "lcid": "1.0.0",
@@ -11139,11 +10291,13 @@
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
+          "dev": true,
           "requires": {
             "os-homedir": "1.0.2",
             "os-tmpdir": "1.0.2"
@@ -11151,11 +10305,13 @@
         },
         "p-finally": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "p-limit": {
           "version": "1.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "p-try": "1.0.0"
           }
@@ -11163,17 +10319,20 @@
         "p-locate": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "p-limit": "1.2.0"
           }
         },
         "p-try": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "package-json": {
           "version": "4.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "got": "6.7.1",
             "registry-auth-token": "3.3.2",
@@ -11184,6 +10343,7 @@
         "pacote": {
           "version": "8.1.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "bluebird": "3.5.1",
             "cacache": "11.2.0",
@@ -11215,6 +10375,7 @@
         "parallel-transform": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cyclist": "0.2.2",
             "inherits": "2.0.3",
@@ -11223,43 +10384,53 @@
         },
         "path-exists": {
           "version": "3.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "path-is-inside": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "path-key": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "performance-now": {
           "version": "2.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "pify": {
           "version": "3.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "prepend-http": {
           "version": "1.0.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "process-nextick-args": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "promise-inflight": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "promise-retry": {
           "version": "1.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "err-code": "1.1.2",
             "retry": "0.10.1"
@@ -11267,43 +10438,51 @@
           "dependencies": {
             "retry": {
               "version": "0.10.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "promzard": {
           "version": "0.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "read": "1.0.7"
           }
         },
         "proto-list": {
           "version": "1.2.4",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "protoduck": {
           "version": "5.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "genfun": "4.0.1"
           }
         },
         "prr": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "pseudomap": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "psl": {
           "version": "1.1.29",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "pump": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "end-of-stream": "1.4.1",
             "once": "1.4.0"
@@ -11312,6 +10491,7 @@
         "pumpify": {
           "version": "1.5.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "duplexify": "3.6.0",
             "inherits": "2.0.3",
@@ -11321,6 +10501,7 @@
             "pump": {
               "version": "2.0.1",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "end-of-stream": "1.4.1",
                 "once": "1.4.0"
@@ -11330,19 +10511,23 @@
         },
         "punycode": {
           "version": "1.4.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "qrcode-terminal": {
           "version": "0.12.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "qs": {
           "version": "6.5.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "query-string": {
           "version": "6.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "decode-uri-component": "0.2.0",
             "strict-uri-encode": "2.0.0"
@@ -11350,11 +10535,13 @@
         },
         "qw": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "rc": {
           "version": "1.2.7",
           "bundled": true,
+          "dev": true,
           "requires": {
             "deep-extend": "0.5.1",
             "ini": "1.3.5",
@@ -11364,13 +10551,15 @@
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "read": {
           "version": "1.0.7",
           "bundled": true,
+          "dev": true,
           "requires": {
             "mute-stream": "0.0.7"
           }
@@ -11378,6 +10567,7 @@
         "read-cmd-shim": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11"
           }
@@ -11385,6 +10575,7 @@
         "read-installed": {
           "version": "4.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "debuglog": "1.0.1",
             "graceful-fs": "4.1.11",
@@ -11398,6 +10589,7 @@
         "read-package-json": {
           "version": "2.0.13",
           "bundled": true,
+          "dev": true,
           "requires": {
             "glob": "7.1.2",
             "graceful-fs": "4.1.11",
@@ -11409,6 +10601,7 @@
         "read-package-tree": {
           "version": "5.2.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "debuglog": "1.0.1",
             "dezalgo": "1.0.3",
@@ -11420,6 +10613,7 @@
         "readable-stream": {
           "version": "2.3.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "core-util-is": "1.0.2",
             "inherits": "2.0.3",
@@ -11433,6 +10627,7 @@
         "readdir-scoped-modules": {
           "version": "1.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "debuglog": "1.0.1",
             "dezalgo": "1.0.3",
@@ -11443,6 +10638,7 @@
         "registry-auth-token": {
           "version": "3.3.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "rc": "1.2.7",
             "safe-buffer": "5.1.2"
@@ -11451,6 +10647,7 @@
         "registry-url": {
           "version": "3.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "rc": "1.2.7"
           }
@@ -11458,6 +10655,7 @@
         "request": {
           "version": "2.88.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aws-sign2": "0.7.0",
             "aws4": "1.8.0",
@@ -11483,23 +10681,28 @@
         },
         "require-directory": {
           "version": "2.1.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "require-main-filename": {
           "version": "1.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "resolve-from": {
           "version": "4.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "retry": {
           "version": "0.12.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "rimraf": {
           "version": "2.6.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "glob": "7.1.2"
           }
@@ -11507,36 +10710,43 @@
         "run-queue": {
           "version": "1.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "aproba": "1.2.0"
           }
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "semver": {
           "version": "5.5.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "semver-diff": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "semver": "5.5.0"
           }
         },
         "set-blocking": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "sha": {
           "version": "2.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "readable-stream": "2.3.6"
@@ -11545,33 +10755,40 @@
         "shebang-command": {
           "version": "1.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "shebang-regex": "1.0.0"
           }
         },
         "shebang-regex": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "slash": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "slide": {
           "version": "1.1.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "smart-buffer": {
           "version": "4.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "socks": {
           "version": "2.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ip": "1.1.5",
             "smart-buffer": "4.0.1"
@@ -11580,6 +10797,7 @@
         "socks-proxy-agent": {
           "version": "4.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "agent-base": "4.2.0",
             "socks": "2.2.0"
@@ -11587,11 +10805,13 @@
         },
         "sorted-object": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "sorted-union-stream": {
           "version": "2.1.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "from2": "1.3.0",
             "stream-iterate": "1.2.0"
@@ -11600,6 +10820,7 @@
             "from2": {
               "version": "1.3.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "inherits": "2.0.3",
                 "readable-stream": "1.1.14"
@@ -11607,11 +10828,13 @@
             },
             "isarray": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "readable-stream": {
               "version": "1.1.14",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "core-util-is": "1.0.2",
                 "inherits": "2.0.3",
@@ -11621,13 +10844,15 @@
             },
             "string_decoder": {
               "version": "0.10.31",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "spdx-correct": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "spdx-expression-parse": "3.0.0",
             "spdx-license-ids": "3.0.0"
@@ -11635,11 +10860,13 @@
         },
         "spdx-exceptions": {
           "version": "2.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "spdx-expression-parse": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "spdx-exceptions": "2.1.0",
             "spdx-license-ids": "3.0.0"
@@ -11647,11 +10874,13 @@
         },
         "spdx-license-ids": {
           "version": "3.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "sshpk": {
           "version": "1.14.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "asn1": "0.2.4",
             "assert-plus": "1.0.0",
@@ -11666,11 +10895,13 @@
         },
         "ssri": {
           "version": "6.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "stream-each": {
           "version": "1.2.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "end-of-stream": "1.4.1",
             "stream-shift": "1.0.0"
@@ -11679,6 +10910,7 @@
         "stream-iterate": {
           "version": "1.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "readable-stream": "2.3.6",
             "stream-shift": "1.0.0"
@@ -11686,15 +10918,18 @@
         },
         "stream-shift": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "strict-uri-encode": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "string-width": {
           "version": "2.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -11702,15 +10937,18 @@
           "dependencies": {
             "ansi-regex": {
               "version": "3.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "is-fullwidth-code-point": {
               "version": "2.0.0",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             },
             "strip-ansi": {
               "version": "4.0.0",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "ansi-regex": "3.0.0"
               }
@@ -11720,32 +10958,38 @@
         "string_decoder": {
           "version": "1.1.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "safe-buffer": "5.1.2"
           }
         },
         "stringify-package": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "ansi-regex": "2.1.1"
           }
         },
         "strip-eof": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "supports-color": {
           "version": "5.4.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "has-flag": "3.0.0"
           }
@@ -11753,6 +10997,7 @@
         "tar": {
           "version": "4.4.6",
           "bundled": true,
+          "dev": true,
           "requires": {
             "chownr": "1.0.1",
             "fs-minipass": "1.2.5",
@@ -11765,28 +11010,33 @@
           "dependencies": {
             "yallist": {
               "version": "3.0.2",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "term-size": {
           "version": "1.2.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "execa": "0.7.0"
           }
         },
         "text-table": {
           "version": "0.2.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "through": {
           "version": "2.3.8",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "through2": {
           "version": "2.0.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "readable-stream": "2.3.6",
             "xtend": "4.0.1"
@@ -11794,15 +11044,18 @@
         },
         "timed-out": {
           "version": "4.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "tiny-relative-date": {
           "version": "1.3.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "tough-cookie": {
           "version": "2.4.3",
           "bundled": true,
+          "dev": true,
           "requires": {
             "psl": "1.1.29",
             "punycode": "1.4.1"
@@ -11811,6 +11064,7 @@
         "tunnel-agent": {
           "version": "0.6.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "safe-buffer": "5.1.2"
           }
@@ -11818,23 +11072,28 @@
         "tweetnacl": {
           "version": "0.14.5",
           "bundled": true,
+          "dev": true,
           "optional": true
         },
         "typedarray": {
           "version": "0.0.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "uid-number": {
           "version": "0.0.6",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "umask": {
           "version": "1.1.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "unique-filename": {
           "version": "1.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "unique-slug": "2.0.0"
           }
@@ -11842,6 +11101,7 @@
         "unique-slug": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "imurmurhash": "0.1.4"
           }
@@ -11849,21 +11109,25 @@
         "unique-string": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "crypto-random-string": "1.0.0"
           }
         },
         "unpipe": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "unzip-response": {
           "version": "2.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "update-notifier": {
           "version": "2.5.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "boxen": "1.3.0",
             "chalk": "2.4.1",
@@ -11880,25 +11144,30 @@
         "url-parse-lax": {
           "version": "1.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "prepend-http": "1.0.4"
           }
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "util-extend": {
           "version": "1.0.3",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "uuid": {
           "version": "3.3.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "validate-npm-package-license": {
           "version": "3.0.4",
           "bundled": true,
+          "dev": true,
           "requires": {
             "spdx-correct": "3.0.0",
             "spdx-expression-parse": "3.0.0"
@@ -11907,6 +11176,7 @@
         "validate-npm-package-name": {
           "version": "3.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "builtins": "1.0.3"
           }
@@ -11914,6 +11184,7 @@
         "verror": {
           "version": "1.10.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "assert-plus": "1.0.0",
             "core-util-is": "1.0.2",
@@ -11923,6 +11194,7 @@
         "wcwidth": {
           "version": "1.0.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "defaults": "1.0.3"
           }
@@ -11930,17 +11202,20 @@
         "which": {
           "version": "1.3.1",
           "bundled": true,
+          "dev": true,
           "requires": {
             "isexe": "2.0.0"
           }
         },
         "which-module": {
           "version": "2.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "wide-align": {
           "version": "1.1.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "string-width": "1.0.2"
           },
@@ -11948,6 +11223,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "code-point-at": "1.1.0",
                 "is-fullwidth-code-point": "1.0.0",
@@ -11959,6 +11235,7 @@
         "widest-line": {
           "version": "2.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "string-width": "2.1.1"
           }
@@ -11966,6 +11243,7 @@
         "worker-farm": {
           "version": "1.6.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "errno": "0.1.7"
           }
@@ -11973,6 +11251,7 @@
         "wrap-ansi": {
           "version": "2.1.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "string-width": "1.0.2",
             "strip-ansi": "3.0.1"
@@ -11981,6 +11260,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "dev": true,
               "requires": {
                 "code-point-at": "1.1.0",
                 "is-fullwidth-code-point": "1.0.0",
@@ -11991,11 +11271,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "write-file-atomic": {
           "version": "2.3.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "graceful-fs": "4.1.11",
             "imurmurhash": "0.1.4",
@@ -12004,23 +11286,28 @@
         },
         "xdg-basedir": {
           "version": "3.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "xtend": {
           "version": "4.0.1",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "y18n": {
           "version": "4.0.0",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "yallist": {
           "version": "2.1.2",
-          "bundled": true
+          "bundled": true,
+          "dev": true
         },
         "yargs": {
           "version": "11.0.0",
           "bundled": true,
+          "dev": true,
           "requires": {
             "cliui": "4.1.0",
             "decamelize": "1.2.0",
@@ -12038,28 +11325,19 @@
           "dependencies": {
             "y18n": {
               "version": "3.2.1",
-              "bundled": true
+              "bundled": true,
+              "dev": true
             }
           }
         },
         "yargs-parser": {
           "version": "9.0.2",
           "bundled": true,
+          "dev": true,
           "requires": {
             "camelcase": "4.1.0"
           }
         }
-      }
-    },
-    "npm-package-arg": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-5.1.2.tgz",
-      "integrity": "sha512-wJBsrf0qpypPT7A0LART18hCdyhpCMxeTtcb0X4IZO2jsP6Om7EHN1d9KSKiqD+KVH030RVNpWS9thk+pb7wzA==",
-      "requires": {
-        "hosted-git-info": "2.5.0",
-        "osenv": "0.1.5",
-        "semver": "5.4.1",
-        "validate-npm-package-name": "3.0.0"
       }
     },
     "npm-path": {
@@ -12071,28 +11349,11 @@
         "which": "1.3.0"
       }
     },
-    "npm-registry-client": {
-      "version": "8.5.0",
-      "resolved": "https://registry.npmjs.org/npm-registry-client/-/npm-registry-client-8.5.0.tgz",
-      "integrity": "sha512-Nkcw24bfECKFNt0FLDQ+PjVqSlKxMggcboXiUBIvjbCnA15xjRO4kCwRDluGNXZjHFLx/vPjN4+ESXyVjpXLbQ==",
-      "requires": {
-        "concat-stream": "1.6.0",
-        "graceful-fs": "4.1.11",
-        "normalize-package-data": "2.4.0",
-        "npm-package-arg": "5.1.2",
-        "npmlog": "4.1.2",
-        "once": "1.4.0",
-        "request": "2.83.0",
-        "retry": "0.10.1",
-        "semver": "5.4.1",
-        "slide": "1.1.6",
-        "ssri": "4.1.6"
-      }
-    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
       "requires": {
         "path-key": "2.0.1"
       }
@@ -12108,21 +11369,11 @@
         "which": "1.3.0"
       }
     },
-    "npmlog": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
-      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-      "requires": {
-        "are-we-there-yet": "1.1.4",
-        "console-control-strings": "1.1.0",
-        "gauge": "2.7.4",
-        "set-blocking": "2.0.0"
-      }
-    },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "dev": true
     },
     "nwmatcher": {
       "version": "1.4.3",
@@ -12133,12 +11384,14 @@
     "oauth-sign": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM=",
+      "dev": true
     },
     "object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true
     },
     "object-copy": {
       "version": "0.1.0",
@@ -12226,6 +11479,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
       "requires": {
         "wrappy": "1.0.2"
       }
@@ -12240,6 +11494,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
       "requires": {
         "minimist": "0.0.10",
         "wordwrap": "0.0.3"
@@ -12248,7 +11503,8 @@
         "minimist": {
           "version": "0.0.10",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
-          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
+          "dev": true
         }
       }
     },
@@ -12289,7 +11545,8 @@
     "os-homedir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M="
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "dev": true
     },
     "os-locale": {
       "version": "2.1.0",
@@ -12311,16 +11568,8 @@
     "os-tmpdir": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
-    },
-    "osenv": {
-      "version": "0.1.5",
-      "resolved": "https://registry.npmjs.org/osenv/-/osenv-0.1.5.tgz",
-      "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
     },
     "p-cancelable": {
       "version": "0.5.0",
@@ -12340,7 +11589,8 @@
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
     },
     "p-is-promise": {
       "version": "1.1.0",
@@ -12402,6 +11652,7 @@
       "version": "4.0.1",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/package-json/-/package-json-4.0.1.tgz",
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
+      "dev": true,
       "requires": {
         "got": "6.7.1",
         "registry-auth-token": "3.3.2",
@@ -12413,6 +11664,7 @@
           "version": "6.7.1",
           "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/got/-/got-6.7.1.tgz",
           "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
+          "dev": true,
           "requires": {
             "create-error-class": "3.0.2",
             "duplexer3": "0.1.4",
@@ -12430,12 +11682,14 @@
         "prepend-http": {
           "version": "1.0.4",
           "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/prepend-http/-/prepend-http-1.0.4.tgz",
-          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
+          "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
+          "dev": true
         },
         "url-parse-lax": {
           "version": "1.0.0",
           "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
           "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
+          "dev": true,
           "requires": {
             "prepend-http": "1.0.4"
           }
@@ -12450,36 +11704,6 @@
       "requires": {
         "repeat-string": "1.6.1"
       }
-    },
-    "parse-git-config": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/parse-git-config/-/parse-git-config-2.0.3.tgz",
-      "integrity": "sha512-Js7ueMZOVSZ3tP8C7E3KZiHv6QQl7lnJ+OkbxoaFazzSa2KyEHqApfGbU3XboUgUnq4ZuUmskUpYKTNx01fm5A==",
-      "requires": {
-        "expand-tilde": "2.0.2",
-        "git-config-path": "1.0.1",
-        "ini": "1.3.5"
-      },
-      "dependencies": {
-        "expand-tilde": {
-          "version": "2.0.2",
-          "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
-          "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-          "requires": {
-            "homedir-polyfill": "1.0.1"
-          }
-        },
-        "ini": {
-          "version": "1.3.5",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
-        }
-      }
-    },
-    "parse-github-repo-url": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/parse-github-repo-url/-/parse-github-repo-url-1.4.1.tgz",
-      "integrity": "sha1-nn2LslKmy2ukJZUGC3v23z28H1A="
     },
     "parse-github-url": {
       "version": "1.0.2",
@@ -12511,7 +11735,8 @@
     "parse-passwd": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
-      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY="
+      "integrity": "sha1-bVuTSkVpk7I9N/QKOC1vFmao5cY=",
+      "dev": true
     },
     "parse-url": {
       "version": "1.3.11",
@@ -12553,17 +11778,20 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
     },
     "path-is-inside": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
-      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM="
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
     },
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
     },
     "path-parse": {
       "version": "1.0.5",
@@ -12593,12 +11821,14 @@
     "performance-now": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+      "dev": true
     },
     "pify": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY="
+      "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+      "dev": true
     },
     "pinkie": {
       "version": "2.0.4",
@@ -12691,29 +11921,6 @@
       "integrity": "sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=",
       "dev": true
     },
-    "prebuild-install": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-2.5.3.tgz",
-      "integrity": "sha512-/rI36cN2g7vDQnKWN8Uzupi++KjyqS9iS+/fpwG4Ea8d0Pip0PQ5bshUNzVwt+/D2MRfhVAplYMMvWLqWrCF/g==",
-      "optional": true,
-      "requires": {
-        "detect-libc": "1.0.3",
-        "expand-template": "1.1.1",
-        "github-from-package": "0.0.0",
-        "minimist": "1.2.0",
-        "mkdirp": "0.5.1",
-        "node-abi": "2.4.3",
-        "noop-logger": "0.1.1",
-        "npmlog": "4.1.2",
-        "os-homedir": "1.0.2",
-        "pump": "2.0.1",
-        "rc": "1.2.5",
-        "simple-get": "2.8.1",
-        "tar-fs": "1.16.3",
-        "tunnel-agent": "0.6.0",
-        "which-pm-runs": "1.0.0"
-      }
-    },
     "prelude-ls": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
@@ -12768,12 +11975,14 @@
     "private": {
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.7.tgz",
-      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE="
+      "integrity": "sha1-aM5eih7woju1cMwoU3tTMqumPvE=",
+      "dev": true
     },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
+      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+      "dev": true
     },
     "progress": {
       "version": "2.0.0",
@@ -12804,27 +12013,14 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
-    },
-    "psl": {
-      "version": "1.1.29",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.29.tgz",
-      "integrity": "sha512-AeUmQ0oLN02flVHXWh9sSJF7mcdFq0ppid/JkErufc3hGIV/AMa8Fo9VgDo/cT2jFdOWoFvHp90qqBH54W+gjQ=="
-    },
-    "pump": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
-      "optional": true,
-      "requires": {
-        "end-of-stream": "1.4.1",
-        "once": "1.4.0"
-      }
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
     },
     "punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+      "dev": true
     },
     "q": {
       "version": "1.5.1",
@@ -12835,7 +12031,8 @@
     "qs": {
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+      "dev": true
     },
     "quick-lru": {
       "version": "1.1.0",
@@ -12888,6 +12085,7 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.5.tgz",
       "integrity": "sha1-J1zWh/bjs2zHVrqibf7oCnkDAf0=",
+      "dev": true,
       "requires": {
         "deep-extend": "0.4.2",
         "ini": "1.3.4",
@@ -12941,6 +12139,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
       "integrity": "sha512-m+qzzcn7KUxEmd1gMbchF+Y2eIUbieUaxkWtptyHywrX0rE8QEYqPC07Vuy4Wm32/xE16NcdBctb8S0Xe/5IeQ==",
+      "dev": true,
       "requires": {
         "core-util-is": "1.0.2",
         "inherits": "2.0.3",
@@ -13011,7 +12210,8 @@
     "regenerate": {
       "version": "1.4.0",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/regenerate/-/regenerate-1.4.0.tgz",
-      "integrity": "sha1-SoVuxLVuQHfFV1icroXnpMiGmhE="
+      "integrity": "sha1-SoVuxLVuQHfFV1icroXnpMiGmhE=",
+      "dev": true
     },
     "regenerate-unicode-properties": {
       "version": "7.0.0",
@@ -13025,17 +12225,8 @@
     "regenerator-runtime": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A=="
-    },
-    "regenerator-transform": {
-      "version": "0.10.1",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-      "integrity": "sha1-HkmWg3Ix2ot/PPQRTXG1aRoGgN0=",
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.7"
-      }
+      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+      "dev": true
     },
     "regex-cache": {
       "version": "0.4.4",
@@ -13077,20 +12268,11 @@
         }
       }
     },
-    "regexpu-core": {
-      "version": "2.0.0",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/regexpu-core/-/regexpu-core-2.0.0.tgz",
-      "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "requires": {
-        "regenerate": "1.4.0",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
-      }
-    },
     "registry-auth-token": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
+      "dev": true,
       "requires": {
         "rc": "1.2.5",
         "safe-buffer": "5.1.1"
@@ -13100,28 +12282,9 @@
       "version": "3.1.0",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
+      "dev": true,
       "requires": {
         "rc": "1.2.5"
-      }
-    },
-    "regjsgen": {
-      "version": "0.2.0",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/regjsgen/-/regjsgen-0.2.0.tgz",
-      "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
-    },
-    "regjsparser": {
-      "version": "0.1.5",
-      "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/regjsparser/-/regjsparser-0.1.5.tgz",
-      "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-      "requires": {
-        "jsesc": "0.5.0"
-      },
-      "dependencies": {
-        "jsesc": {
-          "version": "0.5.0",
-          "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
-        }
       }
     },
     "remove-trailing-separator": {
@@ -13146,6 +12309,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+      "dev": true,
       "requires": {
         "is-finite": "1.0.2"
       }
@@ -13210,6 +12374,7 @@
       "version": "2.83.0",
       "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
       "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+      "dev": true,
       "requires": {
         "aws-sign2": "0.7.0",
         "aws4": "1.6.0",
@@ -13235,29 +12400,11 @@
         "uuid": "3.1.0"
       }
     },
-    "request-debug": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/request-debug/-/request-debug-0.2.0.tgz",
-      "integrity": "sha1-/AVOyBcYGwTKQaBSwTb2HEirr3g=",
-      "requires": {
-        "stringify-clone": "1.1.1"
-      }
-    },
-    "request-promise": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
-      "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
-      "requires": {
-        "bluebird": "3.5.2",
-        "request-promise-core": "1.1.1",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.3.3"
-      }
-    },
     "request-promise-core": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
+      "dev": true,
       "requires": {
         "lodash": "4.17.2"
       }
@@ -13366,11 +12513,6 @@
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
       "dev": true
-    },
-    "retry": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/retry/-/retry-0.10.1.tgz",
-      "integrity": "sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q="
     },
     "revalidator": {
       "version": "0.1.8",
@@ -13508,6 +12650,7 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
       "requires": {
         "is-promise": "2.1.0"
       }
@@ -13538,7 +12681,8 @@
     "safe-buffer": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
-      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+      "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
+      "dev": true
     },
     "safe-regex": {
       "version": "1.1.0",
@@ -13549,11 +12693,6 @@
         "ret": "0.1.15"
       }
     },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
-    },
     "sane": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sane/-/sane-2.0.0.tgz",
@@ -13563,7 +12702,6 @@
         "anymatch": "1.3.2",
         "exec-sh": "0.2.1",
         "fb-watchman": "2.0.0",
-        "fsevents": "1.2.4",
         "minimatch": "3.0.4",
         "minimist": "1.2.0",
         "walker": "1.0.7",
@@ -13908,322 +13046,17 @@
         }
       }
     },
-    "semantic-release-cli": {
-      "version": "4.0.7",
-      "resolved": "https://registry.npmjs.org/semantic-release-cli/-/semantic-release-cli-4.0.7.tgz",
-      "integrity": "sha512-/i4osZ2HNAnl8l5+nr9Qasb0TC1jzh/ouzKNKvthLrRw1oUpgY35L7hF4Lx9BdEQbNkN63Yp41EED18DL1eCNw==",
-      "requires": {
-        "babel-polyfill": "6.26.0",
-        "babel-preset-env": "1.7.0",
-        "babel-register": "6.26.0",
-        "base32": "0.0.6",
-        "clipboardy": "1.2.3",
-        "git-config-path": "1.0.1",
-        "github-url-from-git": "1.5.0",
-        "ini": "1.3.4",
-        "inquirer": "6.2.0",
-        "js-yaml": "3.10.0",
-        "keytar": "4.2.1",
-        "lodash": "4.17.2",
-        "nopt": "4.0.1",
-        "npm": "6.4.1",
-        "npm-registry-client": "8.5.0",
-        "npmlog": "4.1.2",
-        "p-retry": "2.0.0",
-        "parse-git-config": "2.0.3",
-        "parse-github-repo-url": "1.4.1",
-        "pify": "4.0.0",
-        "request": "2.88.0",
-        "request-debug": "0.2.0",
-        "request-promise": "4.2.2",
-        "travis-ci": "2.2.0",
-        "update-notifier": "2.5.0",
-        "user-home": "2.0.0",
-        "validator": "10.7.1"
-      },
-      "dependencies": {
-        "ansi-escapes": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.1.0.tgz",
-          "integrity": "sha512-UgAb8H9D41AQnu/PbWlCofQVcnV4Gs2bBJi9eZPxfU/hgglFh3SMDMENRIqdr7H6XFnXdoknctFByVsCOotTVw=="
-        },
-        "ansi-regex": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
-        },
-        "ansi-styles": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-          "requires": {
-            "color-convert": "1.9.0"
-          }
-        },
-        "aws4": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-          "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
-        },
-        "chalk": {
-          "version": "2.4.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
-          "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-          "requires": {
-            "ansi-styles": "3.2.1",
-            "escape-string-regexp": "1.0.5",
-            "supports-color": "5.5.0"
-          }
-        },
-        "cli-cursor": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
-          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-          "requires": {
-            "restore-cursor": "2.0.0"
-          }
-        },
-        "combined-stream": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "extend": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-        },
-        "external-editor": {
-          "version": "3.0.3",
-          "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
-          "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
-          "requires": {
-            "chardet": "0.7.0",
-            "iconv-lite": "0.4.24",
-            "tmp": "0.0.33"
-          }
-        },
-        "figures": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
-          "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-          "requires": {
-            "escape-string-regexp": "1.0.5"
-          }
-        },
-        "har-validator": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-          "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
-          "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.24",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
-          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
-          "requires": {
-            "safer-buffer": "2.1.2"
-          }
-        },
-        "inquirer": {
-          "version": "6.2.0",
-          "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.0.tgz",
-          "integrity": "sha512-QIEQG4YyQ2UYZGDC4srMZ7BjHOmNk1lR2JQj5UknBapklm6WHA+VVH7N+sUdX3A7NeCfGF8o4X1S3Ao7nAcIeg==",
-          "requires": {
-            "ansi-escapes": "3.1.0",
-            "chalk": "2.4.1",
-            "cli-cursor": "2.1.0",
-            "cli-width": "2.2.0",
-            "external-editor": "3.0.3",
-            "figures": "2.0.0",
-            "lodash": "4.17.10",
-            "mute-stream": "0.0.7",
-            "run-async": "2.3.0",
-            "rxjs": "6.3.2",
-            "string-width": "2.1.1",
-            "strip-ansi": "4.0.0",
-            "through": "2.3.8"
-          },
-          "dependencies": {
-            "lodash": {
-              "version": "4.17.10",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-              "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
-            }
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        },
-        "mime-db": {
-          "version": "1.36.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-          "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
-        },
-        "mime-types": {
-          "version": "2.1.20",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-          "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
-          "requires": {
-            "mime-db": "1.36.0"
-          }
-        },
-        "mute-stream": {
-          "version": "0.0.7",
-          "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-          "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
-        },
-        "oauth-sign": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-        },
-        "onetime": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
-          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-          "requires": {
-            "mimic-fn": "1.1.0"
-          }
-        },
-        "p-retry": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-2.0.0.tgz",
-          "integrity": "sha512-ZbCuzAmiwJ45q4evp/IG9D+5MUllGSUeCWwPt3j/tdYSi1KPkSD+46uqmAA1LhccDhOXv8kYZKNb8x78VflzfA==",
-          "requires": {
-            "retry": "0.12.0"
-          }
-        },
-        "pify": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.0.tgz",
-          "integrity": "sha512-zrSP/KDf9DH3K3VePONoCstgPiYJy9z0SCatZuTpOc7YdnWIqwkWdXOuwlr4uDc7em8QZRsFWsT/685x5InjYg=="
-        },
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-        },
-        "request": {
-          "version": "2.88.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.8.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.2",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.2",
-            "har-validator": "5.1.0",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.20",
-            "oauth-sign": "0.9.0",
-            "performance-now": "2.1.0",
-            "qs": "6.5.2",
-            "safe-buffer": "5.1.2",
-            "tough-cookie": "2.4.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.3.2"
-          }
-        },
-        "restore-cursor": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
-          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-          "requires": {
-            "onetime": "2.0.1",
-            "signal-exit": "3.0.2"
-          }
-        },
-        "retry": {
-          "version": "0.12.0",
-          "resolved": "https://registry.npmjs.org/retry/-/retry-0.12.0.tgz",
-          "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs="
-        },
-        "rxjs": {
-          "version": "6.3.2",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.3.2.tgz",
-          "integrity": "sha512-hV7criqbR0pe7EeL3O66UYVg92IR0XsA97+9y+BWTePK9SKmEI5Qd3Zj6uPnGkNzXsBywBQWTvujPl+1Kn9Zjw==",
-          "requires": {
-            "tslib": "1.9.0"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "string-width": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-          "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-          "requires": {
-            "is-fullwidth-code-point": "2.0.0",
-            "strip-ansi": "4.0.0"
-          }
-        },
-        "strip-ansi": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
-          "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
-          "requires": {
-            "ansi-regex": "3.0.0"
-          }
-        },
-        "supports-color": {
-          "version": "5.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-          "requires": {
-            "has-flag": "3.0.0"
-          }
-        },
-        "tmp": {
-          "version": "0.0.33",
-          "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-          "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-          "requires": {
-            "os-tmpdir": "1.0.2"
-          }
-        },
-        "tough-cookie": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-          "requires": {
-            "psl": "1.1.29",
-            "punycode": "1.4.1"
-          }
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-        }
-      }
-    },
     "semver": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
-      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg=="
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
+      "dev": true
     },
     "semver-diff": {
       "version": "2.1.0",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
+      "dev": true,
       "requires": {
         "semver": "5.4.1"
       }
@@ -14237,7 +13070,8 @@
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "dev": true
     },
     "set-immediate-shim": {
       "version": "1.0.1",
@@ -14261,6 +13095,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
       "requires": {
         "shebang-regex": "1.0.0"
       }
@@ -14268,7 +13103,8 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
     },
     "shell-quote": {
       "version": "1.6.1",
@@ -14302,7 +13138,8 @@
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
     },
     "signale": {
       "version": "1.2.1",
@@ -14355,38 +13192,17 @@
         }
       }
     },
-    "simple-concat": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-      "integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
-      "optional": true
-    },
-    "simple-get": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-      "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
-      "optional": true,
-      "requires": {
-        "decompress-response": "3.3.0",
-        "once": "1.4.0",
-        "simple-concat": "1.0.0"
-      }
-    },
     "slash": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-1.0.0.tgz",
-      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU="
+      "integrity": "sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=",
+      "dev": true
     },
     "slice-ansi": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
       "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
       "dev": true
-    },
-    "slide": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
-      "integrity": "sha1-VusCfWW00tzmyy4tMsTUr8nh1wc="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -14491,6 +13307,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
       "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "dev": true,
       "requires": {
         "hoek": "4.2.1"
       }
@@ -14498,7 +13315,8 @@
     "source-map": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+      "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
     },
     "source-map-resolve": {
       "version": "0.5.0",
@@ -14516,6 +13334,7 @@
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
+      "dev": true,
       "requires": {
         "source-map": "0.5.7"
       }
@@ -14546,6 +13365,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+      "dev": true,
       "requires": {
         "spdx-license-ids": "1.2.2"
       }
@@ -14553,12 +13373,14 @@
     "spdx-expression-parse": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
+      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw=",
+      "dev": true
     },
     "spdx-license-ids": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc=",
+      "dev": true
     },
     "split": {
       "version": "1.0.1",
@@ -14611,12 +13433,14 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
     },
     "sshpk": {
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
       "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+      "dev": true,
       "requires": {
         "asn1": "0.2.3",
         "assert-plus": "1.0.0",
@@ -14631,16 +13455,9 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
         }
-      }
-    },
-    "ssri": {
-      "version": "4.1.6",
-      "resolved": "https://registry.npmjs.org/ssri/-/ssri-4.1.6.tgz",
-      "integrity": "sha512-WUbCdgSAMQjTFZRWvSPpauryvREEA+Krn19rx67UlJEJx/M192ZHxMmJXjZ4tkdFm+Sb0SXGlENeQVlA5wY7kA==",
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stack-trace": {
@@ -14685,7 +13502,8 @@
     "stealthy-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+      "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+      "dev": true
     },
     "stream-combiner2": {
       "version": "1.1.1",
@@ -14737,6 +13555,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
       "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "dev": true,
       "requires": {
         "code-point-at": "1.1.0",
         "is-fullwidth-code-point": "1.0.0",
@@ -14747,14 +13566,10 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
-    },
-    "stringify-clone": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stringify-clone/-/stringify-clone-1.1.1.tgz",
-      "integrity": "sha1-MJojX7Ts/M19OI2+GLqQT6yvQzs="
     },
     "stringify-object": {
       "version": "3.2.2",
@@ -14770,12 +13585,14 @@
     "stringstream": {
       "version": "0.0.5",
       "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
+      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
+      "dev": true
     },
     "strip-ansi": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
       "requires": {
         "ansi-regex": "2.1.1"
       }
@@ -14792,7 +13609,8 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
     },
     "strip-indent": {
       "version": "2.0.0",
@@ -14803,7 +13621,8 @@
     "strip-json-comments": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
     },
     "subarg": {
       "version": "1.0.0",
@@ -14817,7 +13636,8 @@
     "supports-color": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true
     },
     "symbol-observable": {
       "version": "0.2.4",
@@ -14831,49 +13651,11 @@
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
       "dev": true
     },
-    "tar-fs": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
-      "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
-      "optional": true,
-      "requires": {
-        "chownr": "1.0.1",
-        "mkdirp": "0.5.1",
-        "pump": "1.0.3",
-        "tar-stream": "1.6.1"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-          "optional": true,
-          "requires": {
-            "end-of-stream": "1.4.1",
-            "once": "1.4.0"
-          }
-        }
-      }
-    },
-    "tar-stream": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
-      "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
-      "optional": true,
-      "requires": {
-        "bl": "1.2.2",
-        "buffer-alloc": "1.2.0",
-        "end-of-stream": "1.4.1",
-        "fs-constants": "1.0.0",
-        "readable-stream": "2.3.3",
-        "to-buffer": "1.1.1",
-        "xtend": "4.0.1"
-      }
-    },
     "term-size": {
       "version": "1.2.0",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/term-size/-/term-size-1.2.0.tgz",
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
+      "dev": true,
       "requires": {
         "execa": "0.7.0"
       }
@@ -14906,7 +13688,8 @@
     "through": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
     },
     "through2": {
       "version": "2.0.3",
@@ -14921,7 +13704,8 @@
     "timed-out": {
       "version": "4.0.1",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/timed-out/-/timed-out-4.0.1.tgz",
-      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8="
+      "integrity": "sha1-8y6srFoXW+ol1/q1Zas+2HQe9W8=",
+      "dev": true
     },
     "tmp": {
       "version": "0.0.29",
@@ -14938,16 +13722,11 @@
       "integrity": "sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=",
       "dev": true
     },
-    "to-buffer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-      "optional": true
-    },
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",
@@ -15022,6 +13801,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
       "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+      "dev": true,
       "requires": {
         "punycode": "1.4.1"
       }
@@ -15048,120 +13828,6 @@
       "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.6.tgz",
       "integrity": "sha1-y99WD9e5r2MlAv7UD5GMFX6pcTc=",
       "dev": true
-    },
-    "travis-ci": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/travis-ci/-/travis-ci-2.2.0.tgz",
-      "integrity": "sha512-6m+VoKD/va53D4O8I1SLtoLXKLHVUoEL2GksMKLUR0yUqYqco2kj5QB4gdBdFAMw3XL0VBozFsGw8jb6MrrIEQ==",
-      "requires": {
-        "github": "0.1.16",
-        "lodash": "1.3.1",
-        "request": "2.88.0",
-        "underscore.string": "2.2.1"
-      },
-      "dependencies": {
-        "aws4": {
-          "version": "1.8.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-          "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
-        },
-        "combined-stream": {
-          "version": "1.0.6",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
-          "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
-        },
-        "extend": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-          "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-        },
-        "har-validator": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz",
-          "integrity": "sha512-+qnmNjI4OfH2ipQ9VQOw23bBd/ibtfbVdK2fYbY4acTDqKTW/YDp9McimZdDbG8iV9fZizUqQMD5xvriB146TA==",
-          "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
-          }
-        },
-        "lodash": {
-          "version": "1.3.1",
-          "resolved": "http://registry.npmjs.org/lodash/-/lodash-1.3.1.tgz",
-          "integrity": "sha1-pGY7U2hriV/wdOK6UE37dqjit3A="
-        },
-        "mime-db": {
-          "version": "1.36.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz",
-          "integrity": "sha512-L+xvyD9MkoYMXb1jAmzI/lWYAxAMCPvIBSWur0PZ5nOf5euahRLVqH//FKW9mWp2lkqUgYiXPgkzfMUFi4zVDw=="
-        },
-        "mime-types": {
-          "version": "2.1.20",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz",
-          "integrity": "sha512-HrkrPaP9vGuWbLK1B1FfgAkbqNjIuy4eHlIYnFi7kamZyLLrGlo2mpcx0bBmNpKqBtYtAfGbodDddIgddSJC2A==",
-          "requires": {
-            "mime-db": "1.36.0"
-          }
-        },
-        "oauth-sign": {
-          "version": "0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-          "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-        },
-        "qs": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-          "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-        },
-        "request": {
-          "version": "2.88.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
-          "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.8.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.2",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.2",
-            "har-validator": "5.1.0",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.20",
-            "oauth-sign": "0.9.0",
-            "performance-now": "2.1.0",
-            "qs": "6.5.2",
-            "safe-buffer": "5.1.2",
-            "tough-cookie": "2.4.3",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.3.2"
-          }
-        },
-        "safe-buffer": {
-          "version": "5.1.2",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-        },
-        "tough-cookie": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
-          "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
-          "requires": {
-            "psl": "1.1.29",
-            "punycode": "1.4.1"
-          }
-        },
-        "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-        }
-      }
     },
     "travis-deploy-once": {
       "version": "5.0.7",
@@ -15413,7 +14079,8 @@
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
-      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM="
+      "integrity": "sha1-yy4SAwZ+DI3h9hQJS5/kVwTqYAM=",
+      "dev": true
     },
     "ts-jest": {
       "version": "22.0.4",
@@ -15557,7 +14224,8 @@
     "tslib": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
-      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
+      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ==",
+      "dev": true
     },
     "tslint": {
       "version": "5.9.1",
@@ -15657,6 +14325,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -15665,6 +14334,7 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true,
       "optional": true
     },
     "type-check": {
@@ -15679,7 +14349,8 @@
     "typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
-      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+      "dev": true
     },
     "typedoc": {
       "version": "0.10.0",
@@ -15797,11 +14468,6 @@
       "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
       "dev": true
     },
-    "underscore.string": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-2.2.1.tgz",
-      "integrity": "sha1-18D6KvXVoaZ/QlPa7pgTLnM/Dxk="
-    },
     "unicode-canonical-property-names-ecmascript": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/unicode-canonical-property-names-ecmascript/-/unicode-canonical-property-names-ecmascript-1.0.4.tgz",
@@ -15860,6 +14526,7 @@
       "version": "1.0.0",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
+      "dev": true,
       "requires": {
         "crypto-random-string": "1.0.0"
       }
@@ -15919,12 +14586,14 @@
     "unzip-response": {
       "version": "2.0.1",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/unzip-response/-/unzip-response-2.0.1.tgz",
-      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c="
+      "integrity": "sha1-0vD3N9FrBhXnKmk17QQhRXLVb5c=",
+      "dev": true
     },
     "update-notifier": {
       "version": "2.5.0",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/update-notifier/-/update-notifier-2.5.0.tgz",
       "integrity": "sha1-0HRFk+E/Fh5AassdlAi3LK0Ir/Y=",
+      "dev": true,
       "requires": {
         "boxen": "1.3.0",
         "chalk": "2.4.1",
@@ -15942,6 +14611,7 @@
           "version": "3.2.1",
           "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/ansi-styles/-/ansi-styles-3.2.1.tgz",
           "integrity": "sha1-QfuyAkPlCxK+DwS43tvwdSDOhB0=",
+          "dev": true,
           "requires": {
             "color-convert": "1.9.0"
           }
@@ -15950,6 +14620,7 @@
           "version": "2.4.1",
           "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/chalk/-/chalk-2.4.1.tgz",
           "integrity": "sha1-GMSasWoDe26wFSzIPjRxM4IVtm4=",
+          "dev": true,
           "requires": {
             "ansi-styles": "3.2.1",
             "escape-string-regexp": "1.0.5",
@@ -15960,6 +14631,7 @@
           "version": "5.4.0",
           "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/supports-color/-/supports-color-5.4.0.tgz",
           "integrity": "sha1-HGszdALCE3YF7+GfEP7DkPb6q1Q=",
+          "dev": true,
           "requires": {
             "has-flag": "3.0.0"
           }
@@ -15999,18 +14671,11 @@
       "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
       "dev": true
     },
-    "user-home": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
-      "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
-      "requires": {
-        "os-homedir": "1.0.2"
-      }
-    },
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "util.promisify": {
       "version": "1.0.0",
@@ -16047,7 +14712,8 @@
     "uuid": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
-      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g=="
+      "integrity": "sha512-DIWtzUkw04M4k3bf1IcpS2tngXEL26YUD2M0tMDUpnUrz2hgzUBlD55a4FjdLGPvfHxS6uluGWvaVEqgBcVa+g==",
+      "dev": true
     },
     "v8flags": {
       "version": "3.0.1",
@@ -16074,28 +14740,17 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+      "dev": true,
       "requires": {
         "spdx-correct": "1.0.2",
         "spdx-expression-parse": "1.0.4"
       }
     },
-    "validate-npm-package-name": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-      "integrity": "sha1-X6kS2B630MdK/BQN5zF/DKffQ34=",
-      "requires": {
-        "builtins": "1.0.3"
-      }
-    },
-    "validator": {
-      "version": "10.7.1",
-      "resolved": "https://registry.npmjs.org/validator/-/validator-10.7.1.tgz",
-      "integrity": "sha512-tbB5JrTczfeHKLw3PnFRzGFlF1xUAwSgXEDb66EuX1ffCirspYpDEZo3Vc9j38gPdL4JKrDc5UPFfgYiw1IWRQ=="
-    },
     "verror": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "dev": true,
       "requires": {
         "assert-plus": "1.0.0",
         "core-util-is": "1.0.2",
@@ -16105,7 +14760,8 @@
         "assert-plus": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+          "dev": true
         }
       }
     },
@@ -16169,6 +14825,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "dev": true,
       "requires": {
         "isexe": "2.0.0"
       }
@@ -16179,24 +14836,11 @@
       "integrity": "sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=",
       "dev": true
     },
-    "which-pm-runs": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
-      "optional": true
-    },
-    "wide-align": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.2.tgz",
-      "integrity": "sha512-ijDLlyQ7s6x1JgCLur53osjm/UXUYD9+0PbYKrBsYisYXzCxN+HC3mYDNy/dWdmf3AwqwU3CXwDCvsNgGK1S0w==",
-      "requires": {
-        "string-width": "1.0.2"
-      }
-    },
     "widest-line": {
       "version": "2.0.0",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/widest-line/-/widest-line-2.0.0.tgz",
       "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
+      "dev": true,
       "requires": {
         "string-width": "2.1.1"
       },
@@ -16204,17 +14848,20 @@
         "ansi-regex": {
           "version": "3.0.0",
           "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/ansi-regex/-/ansi-regex-3.0.0.tgz",
-          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
+          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+          "dev": true
         },
         "string-width": {
           "version": "2.1.1",
           "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/string-width/-/string-width-2.1.1.tgz",
           "integrity": "sha1-q5Pyeo3BPSjKyBXEYhQ6bZASrp4=",
+          "dev": true,
           "requires": {
             "is-fullwidth-code-point": "2.0.0",
             "strip-ansi": "4.0.0"
@@ -16224,6 +14871,7 @@
           "version": "4.0.0",
           "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/strip-ansi/-/strip-ansi-4.0.0.tgz",
           "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+          "dev": true,
           "requires": {
             "ansi-regex": "3.0.0"
           }
@@ -16281,7 +14929,8 @@
     "wordwrap": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+      "dev": true
     },
     "wrap-ansi": {
       "version": "2.1.0",
@@ -16296,12 +14945,14 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
     },
     "write-file-atomic": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
+      "dev": true,
       "requires": {
         "graceful-fs": "4.1.11",
         "imurmurhash": "0.1.4",
@@ -16322,7 +14973,8 @@
     "xdg-basedir": {
       "version": "3.0.0",
       "resolved": "http://artifactory.infinitecampus.com:80/artifactory/api/npm/npm-snapshot-virtual/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
-      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+      "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ=",
+      "dev": true
     },
     "xml-name-validator": {
       "version": "3.0.0",
@@ -16339,7 +14991,8 @@
     "xtend": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "dev": true
     },
     "y18n": {
       "version": "3.2.1",
@@ -16350,7 +15003,8 @@
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
     },
     "yargs": {
       "version": "11.0.0",

--- a/package.json
+++ b/package.json
@@ -108,8 +108,5 @@
     "typedoc": "^0.10.0",
     "typescript": "^2.6.2",
     "validate-commit-msg": "^2.12.2"
-  },
-  "dependencies": {
-    "semantic-release-cli": "^4.0.7"
   }
 }

--- a/src/files/rsql-filter-list.ts
+++ b/src/files/rsql-filter-list.ts
@@ -10,11 +10,15 @@ export class RSQLFilterList {
   }
 
   public and(filter: RSQLFilterExpression | RSQLFilterList) {
-    this.andList.push(filter);
+    if (filter !== undefined && filter !== null && filter.build() !== '') {
+      this.andList.push(filter);
+    }
   }
 
   public or(filter: RSQLFilterExpression | RSQLFilterList) {
-    this.orList.push(filter);
+    if (filter !== undefined && filter !== null && filter.build() !== '') {
+      this.orList.push(filter);
+    }
   }
 
   /**

--- a/test/rsql-criteria.test.ts
+++ b/test/rsql-criteria.test.ts
@@ -115,6 +115,23 @@ describe('RSQLCriteria test', () => {
     );
   });
 
+  it('should allow you to combine two RSQLCriteria instances with an "and" while disregarding blank filters', () => {
+    let criteria1 = new RSQLCriteria();
+    criteria1.pageSize = 10;
+    criteria1.pageNumber = 1;
+    criteria1.orderBy.add('code', 'asc');
+    criteria1.filters.and(new RSQLFilterExpression('code', Operators.Contains, 'a'));
+
+    let criteria2 = new RSQLCriteria();
+
+    criteria1.and(criteria2);
+    expect(criteria1.build()).toEqual(
+      `$where=code==${encodeURIComponent('"*a*"')}&$orderBy=${encodeURIComponent(
+        'code asc'
+      )}&$pageSize=10&$includeTotalCount=true&$pageNumber=1`
+    );
+  });
+
   it('should allow you to combine two RSQLCriteria instances with an or', () => {
     let criteria1 = new RSQLCriteria();
     criteria1.pageSize = 10;
@@ -130,6 +147,23 @@ describe('RSQLCriteria test', () => {
       `$where=(code==${encodeURIComponent('"*a*"')}${encodeURIComponent(
         ' or '
       )}description==${encodeURIComponent('"*b*"')})&$orderBy=${encodeURIComponent(
+        'code asc'
+      )}&$pageSize=10&$includeTotalCount=true&$pageNumber=1`
+    );
+  });
+
+  it('should allow you to combine two RSQLCriteria instances with an "or" while disregarding blank filters', () => {
+    let criteria1 = new RSQLCriteria();
+    criteria1.pageSize = 10;
+    criteria1.pageNumber = 1;
+    criteria1.orderBy.add('code', 'asc');
+    criteria1.filters.and(new RSQLFilterExpression('code', Operators.Contains, 'a'));
+
+    let criteria2 = new RSQLCriteria();
+
+    criteria1.or(criteria2);
+    expect(criteria1.build()).toEqual(
+      `$where=code==${encodeURIComponent('"*a*"')}&$orderBy=${encodeURIComponent(
         'code asc'
       )}&$pageSize=10&$includeTotalCount=true&$pageNumber=1`
     );


### PR DESCRIPTION
RSQLCriteria objects that don't contain any filters can now be safely combined together and don't
produce invalid RSQL syntax.  Also removed a dependency on the semantic-release-cli that was added
in error.