### PR TITLE
fix(Expression): make date strings ISO 8601 compliant

### DIFF
--- a/src/files/rsql-filter-expression.ts
+++ b/src/files/rsql-filter-expression.ts
@@ -49,11 +49,35 @@ export class RSQLFilterExpression {
       valueString = quotedValues.join(',');
     }
     if (this.value instanceof Date) {
-      valueString = [
-        this.value.getFullYear(),
-        this.value.getMonth() + 1,
-        this.value.getDate()
-      ].join('-');
+      let year = this.value.getFullYear();
+      let month = this.value.getMonth() + 1;
+      let date = this.value.getDate();
+
+      // Ensure that all year values have four digits, and that month and
+      // date values have two digits, by adding leading zeros as necessary
+      let yearString = String(year);
+      let monthString = String(month);
+      let dateString = String(date);
+
+      if (year === 0) {
+        yearString = '0000';
+      } else if (year < 10) {
+        yearString = `000${yearString}`;
+      } else if (year < 100) {
+        yearString = `00${yearString}`;
+      } else if (year < 1000) {
+        yearString = `0${yearString}`;
+      }
+
+      if (month < 10) {
+        monthString = `0${monthString}`;
+      }
+
+      if (date < 10) {
+        dateString = `0${dateString}`;
+      }
+
+      valueString = [yearString, monthString, dateString].join('-');
       shouldQuote = true;
     }
     if (this.value === null) {

--- a/test/rsql-filter-expresion.test.ts
+++ b/test/rsql-filter-expresion.test.ts
@@ -63,13 +63,6 @@ describe('RSQLFilterExpression', () => {
     expect(ex.build()).toEqual(`code${encodeURIComponent('>')}123`);
   });
 
-  it('should handle the GreaterThan operator for a date object', () => {
-    // dates months are 0 indexed
-    let today = new Date(2018, 10, 25);
-    let ex = new RSQLFilterExpression('code', Operators.GreaterThan, today);
-    expect(ex.build()).toEqual(`code${encodeURIComponent('>')}2018-11-25`);
-  });
-
   it('should handle the GreaterThanEqualTo operator', () => {
     let ex = new RSQLFilterExpression('code', Operators.GreaterThanEqualTo, 123);
     expect(ex.build()).toEqual(`code${encodeURIComponent('>=')}123`);
@@ -144,5 +137,48 @@ describe('RSQLFilterExpression', () => {
         '"false"'
       )},${encodeURIComponent('"456"')})`
     );
+  });
+
+  it('should handle Date objects', () => {
+    // date months are 0 indexed
+    let date = new Date(2018, 9, 21);
+    let ex = new RSQLFilterExpression('code', Operators.GreaterThan, date);
+    expect(ex.build()).toEqual(`code${encodeURIComponent('>')}2018-10-21`);
+
+    // years should always have four digits, and months and dates should always have two
+    date = new Date(0, 8, 9);
+    date.setFullYear(0);
+    ex = new RSQLFilterExpression('code', Operators.GreaterThan, date);
+    expect(ex.build()).toEqual(`code${encodeURIComponent('>')}0000-09-09`);
+
+    date = new Date(4, 8, 9);
+    date.setFullYear(9);
+    ex = new RSQLFilterExpression('code', Operators.GreaterThan, date);
+    expect(ex.build()).toEqual(`code${encodeURIComponent('>')}0009-09-09`);
+
+    date = new Date(4, 8, 10);
+    date.setFullYear(10);
+    ex = new RSQLFilterExpression('code', Operators.GreaterThan, date);
+    expect(ex.build()).toEqual(`code${encodeURIComponent('>')}0010-09-10`);
+
+    date = new Date(4, 9, 9);
+    date.setFullYear(99);
+    ex = new RSQLFilterExpression('code', Operators.GreaterThan, date);
+    expect(ex.build()).toEqual(`code${encodeURIComponent('>')}0099-10-09`);
+
+    date = new Date(4, 9, 10);
+    date.setFullYear(100);
+    ex = new RSQLFilterExpression('code', Operators.GreaterThan, date);
+    expect(ex.build()).toEqual(`code${encodeURIComponent('>')}0100-10-10`);
+
+    date = new Date(4, 9, 9);
+    date.setFullYear(999);
+    ex = new RSQLFilterExpression('code', Operators.GreaterThan, date);
+    expect(ex.build()).toEqual(`code${encodeURIComponent('>')}0999-10-09`);
+
+    date = new Date(4, 9, 9);
+    date.setFullYear(1000);
+    ex = new RSQLFilterExpression('code', Operators.GreaterThan, date);
+    expect(ex.build()).toEqual(`code${encodeURIComponent('>')}1000-10-09`);
   });
 });


### PR DESCRIPTION
Dates with months or dates less than 10, or years with less than four
digits, will now have their string values generated with leading zeros
if necessary for ISO 8601 compliance (so years will always have four
digits, and months and dates will always have two).

For example: April 7 in year 19 now generates as "0019-04-07"
instead of "19-4-7".