### PR TITLE
Add support for custom operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ let queryStringPart = list.build();
 // returns blah=="123"
 ```
 
+
+### Builder with Custom Operators
+
+```javascript
+let value: 123;
+let builder: RSQLFilter = new RSQLFilterBuilder();
+let list = builder.column('blah').custom('=myCustomOp=', `someFunctionOnServer(${value})`).toList();
+let queryStringPart = list.build();
+// returns =myCustomOp="someFunctionOnServer(123)"
+```
+
+
 Or a more complex example that shows chaining of the expressions:
 ```javascript
 let rsql: RSQLCriteria = new RSQLCriteria();
@@ -70,6 +82,7 @@ criteria1.and(criteria2);
 criteria1.build();
 //returns $pageSize=10 instead of pageSize = 5
 ```
+
 
 ### A note on function names
 This library has been tested against a SQL Server backend and some irregularities have been found.  A RSQL `==` operation turns into a `LIKE` in SQL Server so that wildcard characters are available for use.  However, in most other languages an `equals` operation is an exact match.  To handle this, the `Operators.Equal` and `RSQLFilterBuilder.equalTo` methods will create an `=in=` RSQL string.  This doesn't allow wildcards to be used in and will intuitively make more sense for those of us that are used to equals meaning exactly equal to.  Wildcard characters are still allowed to be passed in, but they will be interpretted as the characters themselves and not wildcards.

--- a/src/files/rsql-expression-parts.ts
+++ b/src/files/rsql-expression-parts.ts
@@ -20,6 +20,7 @@ export interface RSQLColumn {
   lessThanOrEqualTo(value: string | Date | number): RSQLCompleteExpression;
   in(value: Array<string | number | boolean>): RSQLCompleteExpression;
   notIn(value: Array<string | number | boolean>): RSQLCompleteExpression;
+  custom(op: string, value: string | Date | number | boolean): RSQLCompleteExpression;
   isNull(): RSQLCompleteExpression;
   isNotNull(): RSQLCompleteExpression;
   isEmpty(): RSQLCompleteExpression;

--- a/src/files/rsql-filter-builder.ts
+++ b/src/files/rsql-filter-builder.ts
@@ -135,6 +135,11 @@ export class RSQLFilterBuilder implements RSQLFilter, RSQLColumn, RSQLCompleteEx
     return this;
   }
 
+  custom(op: string, value: string | Date | number | boolean): RSQLCompleteExpression {
+    this.addToList(new RSQLFilterExpression(this.columnName, op as Operators, value));
+    return this;
+  }
+
   and(): RSQLFilter {
     this.connector = 'and';
     return this;

--- a/src/files/rsql-filter-expression.ts
+++ b/src/files/rsql-filter-expression.ts
@@ -139,6 +139,8 @@ export class RSQLFilterExpression {
       case Operators.IsNotNull:
         filterString += '!=null';
         break;
+      default:
+        filterString += encodeURIComponent(this.operator) + valueString;
     }
 
     return filterString;

--- a/test/rsql-filter-builder.test.ts
+++ b/test/rsql-filter-builder.test.ts
@@ -265,6 +265,15 @@ describe('RSQLFilterBuilder', () => {
     expect(list.build()).toEqual(`blah!=${encodeURIComponent('""')}`);
   });
 
+  it('should build the proper string with a custom operator', () => {
+    let builder: RSQLFilter = new RSQLFilterBuilder();
+    let list = builder
+      .column('blah')
+      .custom('>=', '123')
+      .toList();
+    expect(list.build()).toEqual(`blah${encodeURIComponent('>=')}123`);
+  });
+
   it('should handle the group capabilities', () => {
     let builder: RSQLFilter = new RSQLFilterBuilder();
     let list = builder


### PR DESCRIPTION
The idea here is to support custom RSQL operators, so we can express predicates like 'where location within "Ontario"'.

It has been achieved by passing casting the string operator to type Operator, which is less than ideal so please feel free to re-implement as you see fit.  A more correct solution would be to make Operator into a class, but I wanted to avoid too much refactoring.

Thanks for the great library!