### PR TITLE
fix(Expression): remove use of Object.values() and String.prototype.includes()

### DIFF
--- a/src/files/rsql-filter-expression.ts
+++ b/src/files/rsql-filter-expression.ts
@@ -14,12 +14,12 @@ export class RSQLFilterExpression {
     value: string | Array<string | number | boolean> | Date | number | boolean | undefined
   ) {
     this.field = field;
-    if (Object.values(Operators).includes(operator)) {
-      this.operator = operator as Operators;
-      this.customOperator = undefined;
-    } else {
+    if (typeof operator === 'object' && this.instanceOfCustomOperator(operator)) {
       this.operator = undefined;
       this.customOperator = operator as CustomOperator;
+    } else {
+      this.operator = operator as Operators;
+      this.customOperator = undefined;
     }
 
     this.value = value;
@@ -155,6 +155,10 @@ export class RSQLFilterExpression {
     }
 
     return filterString;
+  }
+
+  private instanceOfCustomOperator(object: any): object is CustomOperator {
+    return 'convertToRSQLString' in object;
   }
 }
 


### PR DESCRIPTION
These methods are not supported in IE11. As a result, any RSQL coming from IE11 will throw an error.

The original functionality will work the same as before.

**Documentation**
[Object.values()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_objects/Object/values#Browser_compatibility)
[String.prototype.includes()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes#Browser_compatibility)