### PR TITLE
feat(filters): added build option to prevent encoding values

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,24 @@ criteria1.build();
 // returns $pageSize=10 instead of pageSize = 5
 ```
 
+### Build Options
+An optional `RSQLBuildOptions` object can be passed into each of the `build()` methods to change the behavior of how the strings get built.
+#### encodeString
+`encodeString` can be used to chose whether or not you want the results to be encoded or not.  By default the library WILL encode the resulting string, but if you pass in `{encodeString: false}` to the `build()` method, then the results will not be encoded.  Example:
+```javascript
+const builder: RSQLFilter = new RSQLFilterBuilder();
+const list = builder
+  .column('blah').equalTo('123')
+  .and().column('name').equalTo('John')
+  .toList();
+expect(list.build()).toEqual(
+  `(blah=in=%22123%22%20and%20name=in=%22John%22)`
+);
+expect(list.build({encodeString: false})).toEqual(
+  `(blah=in="123" and name=in="John")`
+);
+```
+
 ### A note on function names
 This library has been tested against a SQL Server backend and some irregularities have been found.  A RSQL `==` operation turns into a `LIKE` in SQL Server so that wildcard characters are available for use.  However, in most other languages an `equals` operation is an exact match.  To handle this, the `Operators.Equal` and `RSQLFilterBuilder.equalTo` methods will create an `=in=` RSQL string.  This doesn't allow wildcards to be used in and will intuitively make more sense for those of us that are used to equals meaning exactly equal to.  Wildcard characters are still allowed to be passed in, but they will be interpreted as the characters themselves and not wildcards.
 

--- a/src/files/rsql-build-options.ts
+++ b/src/files/rsql-build-options.ts
@@ -1,0 +1,7 @@
+export interface RSQLBuildOptions {
+  /**
+   * Determines if the whole string should be encoded or not.  
+   * If you are passing the params in an Angular HttpClient BODY, then set this value to false when calling build()
+   */
+  encodeString?: boolean;
+}

--- a/src/files/rsql-criteria.ts
+++ b/src/files/rsql-criteria.ts
@@ -1,5 +1,6 @@
 import { RSQLFilterList } from './rsql-filter-list';
 import { RSQLOrderByList } from './rsql-order-by-list';
+import { RSQLBuildOptions } from './rsql-build-options';
 
 /**
  * Main class for bringing together API filtering, sorting and pagination.
@@ -42,9 +43,9 @@ export class RSQLCriteria {
    * Builds the query string that will be needed to send down to the server side API.
    * Combines the keywords with their appropriate clauses to create the string.
    */
-  public build(): string {
+  public build(options: RSQLBuildOptions = { encodeString: true }): string {
     const queryStringParts: string[] = [];
-    const whereClause = this.filters.build();
+    const whereClause = this.filters.build(options);
     if (whereClause !== '') {
       queryStringParts.push(`${this.whereKeyword}=${whereClause}`);
     }

--- a/src/files/rsql-filter-list.ts
+++ b/src/files/rsql-filter-list.ts
@@ -1,4 +1,5 @@
-import { RSQLFilterExpression } from './rsql-filter-expression';
+import { RSQLBuildOptions } from "./rsql-build-options";
+import { RSQLFilterExpression } from "./rsql-filter-expression";
 
 export class RSQLFilterList {
   private andList: Array<RSQLFilterExpression | RSQLFilterList>;
@@ -11,14 +12,14 @@ export class RSQLFilterList {
 
   /* eslint-disable @typescript-eslint/explicit-module-boundary-types*/
   public and(filter: RSQLFilterExpression | RSQLFilterList) {
-    if (filter !== undefined && filter !== null && filter.build() !== '') {
+    if (filter !== undefined && filter !== null && filter.build() !== "") {
       this.andList.push(filter);
     }
   }
 
   /* eslint-disable @typescript-eslint/explicit-module-boundary-types*/
   public or(filter: RSQLFilterExpression | RSQLFilterList) {
-    if (filter !== undefined && filter !== null && filter.build() !== '') {
+    if (filter !== undefined && filter !== null && filter.build() !== "") {
       this.orList.push(filter);
     }
   }
@@ -28,29 +29,29 @@ export class RSQLFilterList {
    * If there is more than one filter expression, it puts
    * parenthesis around the expression.
    */
-  public build(): string {
-    let filterString = '';
+  public build(options: RSQLBuildOptions = { encodeString: true }): string {
+    let filterString = "";
     const includeParens = this.andList.length + this.orList.length > 1;
     let includeConnector = false;
     if (includeParens) {
-      filterString += '(';
+      filterString += "(";
     }
     for (const filter of this.andList) {
       if (includeConnector) {
-        filterString += encodeURIComponent(' and ');
+        filterString += options.encodeString ? encodeURIComponent(" and ") : " and ";
       }
-      filterString += filter.build();
+      filterString += filter.build(options);
       includeConnector = true;
     }
     for (const filter of this.orList) {
       if (includeConnector) {
-        filterString += encodeURIComponent(' or ');
+        filterString += options.encodeString ? encodeURIComponent(" or ") : " or ";
       }
-      filterString += filter.build();
+      filterString += filter.build(options);
       includeConnector = true;
     }
     if (includeParens) {
-      filterString += ')';
+      filterString += ")";
     }
 
     return filterString;

--- a/test/rsql-criteria.test.ts
+++ b/test/rsql-criteria.test.ts
@@ -1,115 +1,116 @@
-import { RSQLCriteria } from '../src/files/rsql-criteria';
-import { RSQLFilterExpression } from '../src/files/rsql-filter-expression';
-import { Operators } from '../src/files/rsql-filter-operators';
+import { RSQLFilterBuilder } from "../src";
+import { RSQLCriteria } from "../src/files/rsql-criteria";
+import { RSQLFilterExpression } from "../src/files/rsql-filter-expression";
+import { Operators } from "../src/files/rsql-filter-operators";
 
-describe('RSQLCriteria test', () => {
-  it('works if true is truthy', () => {
+describe("RSQLCriteria test", () => {
+  it("works if true is truthy", () => {
     expect(true).toBeTruthy();
   });
 
-  it('RSQLCriteria is instantiable', () => {
+  it("RSQLCriteria is instantiable", () => {
     expect(new RSQLCriteria()).toBeInstanceOf(RSQLCriteria);
   });
 
-  it('should build nothing if there are no filters or order by clause', () => {
+  it("should build nothing if there are no filters or order by clause", () => {
     const criteria = new RSQLCriteria();
-    expect(criteria.build()).toEqual('');
+    expect(criteria.build()).toEqual("");
   });
 
-  it('should build a where clause when filters are passed in', () => {
+  it("should build a where clause when filters are passed in", () => {
     const criteria = new RSQLCriteria();
-    criteria.filters.and(new RSQLFilterExpression('code', Operators.Equal, 'abc'));
+    criteria.filters.and(new RSQLFilterExpression("code", Operators.Equal, "abc"));
     expect(criteria.build()).toEqual(`$where=code=in=${encodeURIComponent('"abc"')}`);
   });
 
-  it('should build an orderBy clause when order by expressions are passed in', () => {
+  it("should build an orderBy clause when order by expressions are passed in", () => {
     const criteria = new RSQLCriteria();
-    criteria.orderBy.add('code', 'asc');
-    expect(criteria.build()).toEqual(`$orderBy=${encodeURIComponent('code asc')}`);
+    criteria.orderBy.add("code", "asc");
+    expect(criteria.build()).toEqual(`$orderBy=${encodeURIComponent("code asc")}`);
   });
 
-  it('should build a combined string of filters and order by clauses', () => {
+  it("should build a combined string of filters and order by clauses", () => {
     const criteria = new RSQLCriteria();
-    criteria.orderBy.add('code', 'asc');
-    criteria.filters.and(new RSQLFilterExpression('code', Operators.Equal, 'abc'));
+    criteria.orderBy.add("code", "asc");
+    criteria.filters.and(new RSQLFilterExpression("code", Operators.Equal, "abc"));
     expect(criteria.build()).toEqual(
-      `$where=code=in=${encodeURIComponent('"abc"')}&$orderBy=${encodeURIComponent('code asc')}`
+      `$where=code=in=${encodeURIComponent('"abc"')}&$orderBy=${encodeURIComponent("code asc")}`
     );
   });
 
-  it('should build an orderBy clause when order by expressions are passed in with an overridden orderBy keyword', () => {
-    const criteria = new RSQLCriteria('$where', '$order');
-    criteria.orderBy.add('code', 'asc');
-    expect(criteria.build()).toEqual('$order=' + encodeURIComponent('code asc'));
+  it("should build an orderBy clause when order by expressions are passed in with an overridden orderBy keyword", () => {
+    const criteria = new RSQLCriteria("$where", "$order");
+    criteria.orderBy.add("code", "asc");
+    expect(criteria.build()).toEqual("$order=" + encodeURIComponent("code asc"));
   });
 
-  it('should build a where clause when filters are passed in with a customized where keyword', () => {
-    const criteria = new RSQLCriteria('$filter');
-    criteria.filters.and(new RSQLFilterExpression('code', Operators.Equal, 'abc'));
+  it("should build a where clause when filters are passed in with a customized where keyword", () => {
+    const criteria = new RSQLCriteria("$filter");
+    criteria.filters.and(new RSQLFilterExpression("code", Operators.Equal, "abc"));
     expect(criteria.build()).toEqual(`$filter=code=in=${encodeURIComponent('"abc"')}`);
   });
 
-  it('should add in pageSize when that has been set.', () => {
+  it("should add in pageSize when that has been set.", () => {
     const criteria = new RSQLCriteria();
     criteria.pageSize = 10;
-    expect(criteria.build()).toEqual('$pageSize=10&$includeTotalCount=true');
+    expect(criteria.build()).toEqual("$pageSize=10&$includeTotalCount=true");
   });
 
-  it('should not add in totalCount when that has been turned off.', () => {
+  it("should not add in totalCount when that has been turned off.", () => {
     const criteria = new RSQLCriteria();
     criteria.pageSize = 10;
     criteria.includeTotalCount = false;
-    expect(criteria.build()).toEqual('$pageSize=10');
+    expect(criteria.build()).toEqual("$pageSize=10");
   });
 
-  it('should add in pageNumber when that has been set.', () => {
+  it("should add in pageNumber when that has been set.", () => {
     const criteria = new RSQLCriteria();
     criteria.pageNumber = 3;
-    expect(criteria.build()).toEqual('$pageNumber=3');
+    expect(criteria.build()).toEqual("$pageNumber=3");
   });
 
-  it('should include all pagination parts when they are set.', () => {
+  it("should include all pagination parts when they are set.", () => {
     const criteria = new RSQLCriteria();
     criteria.pageSize = 10;
     criteria.pageNumber = 2;
-    expect(criteria.build()).toEqual('$pageSize=10&$includeTotalCount=true&$pageNumber=2');
+    expect(criteria.build()).toEqual("$pageSize=10&$includeTotalCount=true&$pageNumber=2");
   });
 
-  it('should override the pageSizeKeyword when that has been set.', () => {
-    const criteria = new RSQLCriteria('$where', '$orderBy', '$take');
+  it("should override the pageSizeKeyword when that has been set.", () => {
+    const criteria = new RSQLCriteria("$where", "$orderBy", "$take");
     criteria.pageSize = 10;
-    expect(criteria.build()).toEqual('$take=10&$includeTotalCount=true');
+    expect(criteria.build()).toEqual("$take=10&$includeTotalCount=true");
   });
 
-  it('should override the includeTotalCountKeyword when that has been set.', () => {
-    const criteria = new RSQLCriteria('$where', '$orderBy', '$take', 'total');
+  it("should override the includeTotalCountKeyword when that has been set.", () => {
+    const criteria = new RSQLCriteria("$where", "$orderBy", "$take", "total");
     criteria.pageSize = 10;
-    expect(criteria.build()).toEqual('$take=10&total=true');
+    expect(criteria.build()).toEqual("$take=10&total=true");
   });
 
-  it('should override the includeTotalCountKeyword when that has been set.', () => {
-    const criteria = new RSQLCriteria('$where', '$orderBy', '$take', 'total', '$skip');
+  it("should override the includeTotalCountKeyword when that has been set.", () => {
+    const criteria = new RSQLCriteria("$where", "$orderBy", "$take", "total", "$skip");
     criteria.pageSize = 10;
     criteria.pageNumber = 2;
-    expect(criteria.build()).toEqual('$take=10&total=true&$skip=2');
+    expect(criteria.build()).toEqual("$take=10&total=true&$skip=2");
   });
 
-  it('should allow you to combine two RSQLCriteria instances with an and', () => {
+  it("should allow you to combine two RSQLCriteria instances with an and", () => {
     const criteria1 = new RSQLCriteria();
     criteria1.pageSize = 10;
     criteria1.pageNumber = 1;
-    criteria1.orderBy.add('code', 'asc');
-    criteria1.filters.and(new RSQLFilterExpression('code', Operators.Contains, 'a'));
+    criteria1.orderBy.add("code", "asc");
+    criteria1.filters.and(new RSQLFilterExpression("code", Operators.Contains, "a"));
 
     const criteria2 = new RSQLCriteria();
-    criteria2.filters.and(new RSQLFilterExpression('description', Operators.Contains, 'b'));
+    criteria2.filters.and(new RSQLFilterExpression("description", Operators.Contains, "b"));
 
     criteria1.and(criteria2);
     expect(criteria1.build()).toEqual(
       `$where=(code==${encodeURIComponent('"*a*"')}${encodeURIComponent(
-        ' and '
+        " and "
       )}description==${encodeURIComponent('"*b*"')})&$orderBy=${encodeURIComponent(
-        'code asc'
+        "code asc"
       )}&$pageSize=10&$includeTotalCount=true&$pageNumber=1`
     );
   });
@@ -118,35 +119,35 @@ describe('RSQLCriteria test', () => {
     const criteria1 = new RSQLCriteria();
     criteria1.pageSize = 10;
     criteria1.pageNumber = 1;
-    criteria1.orderBy.add('code', 'asc');
-    criteria1.filters.and(new RSQLFilterExpression('code', Operators.Contains, 'a'));
+    criteria1.orderBy.add("code", "asc");
+    criteria1.filters.and(new RSQLFilterExpression("code", Operators.Contains, "a"));
 
     const criteria2 = new RSQLCriteria();
 
     criteria1.and(criteria2);
     expect(criteria1.build()).toEqual(
       `$where=code==${encodeURIComponent('"*a*"')}&$orderBy=${encodeURIComponent(
-        'code asc'
+        "code asc"
       )}&$pageSize=10&$includeTotalCount=true&$pageNumber=1`
     );
   });
 
-  it('should allow you to combine two RSQLCriteria instances with an or', () => {
+  it("should allow you to combine two RSQLCriteria instances with an or", () => {
     const criteria1 = new RSQLCriteria();
     criteria1.pageSize = 10;
     criteria1.pageNumber = 1;
-    criteria1.orderBy.add('code', 'asc');
-    criteria1.filters.and(new RSQLFilterExpression('code', Operators.Contains, 'a'));
+    criteria1.orderBy.add("code", "asc");
+    criteria1.filters.and(new RSQLFilterExpression("code", Operators.Contains, "a"));
 
     const criteria2 = new RSQLCriteria();
-    criteria2.filters.and(new RSQLFilterExpression('description', Operators.Contains, 'b'));
+    criteria2.filters.and(new RSQLFilterExpression("description", Operators.Contains, "b"));
 
     criteria1.or(criteria2);
     expect(criteria1.build()).toEqual(
       `$where=(code==${encodeURIComponent('"*a*"')}${encodeURIComponent(
-        ' or '
+        " or "
       )}description==${encodeURIComponent('"*b*"')})&$orderBy=${encodeURIComponent(
-        'code asc'
+        "code asc"
       )}&$pageSize=10&$includeTotalCount=true&$pageNumber=1`
     );
   });
@@ -155,16 +156,33 @@ describe('RSQLCriteria test', () => {
     const criteria1 = new RSQLCriteria();
     criteria1.pageSize = 10;
     criteria1.pageNumber = 1;
-    criteria1.orderBy.add('code', 'asc');
-    criteria1.filters.and(new RSQLFilterExpression('code', Operators.Contains, 'a'));
+    criteria1.orderBy.add("code", "asc");
+    criteria1.filters.and(new RSQLFilterExpression("code", Operators.Contains, "a"));
 
     const criteria2 = new RSQLCriteria();
 
     criteria1.or(criteria2);
     expect(criteria1.build()).toEqual(
       `$where=code==${encodeURIComponent('"*a*"')}&$orderBy=${encodeURIComponent(
-        'code asc'
+        "code asc"
       )}&$pageSize=10&$includeTotalCount=true&$pageNumber=1`
+    );
+  });
+
+  it("should pass down the build options appropriately", () => {
+    const criteria1 = new RSQLCriteria();
+    criteria1.filters.and(
+      new RSQLFilterBuilder()
+        .column("foo")
+        .equalTo("bar")
+        .or()
+        .column("bar")
+        .equalTo("baz")
+        .toList()
+    );
+    expect(criteria1.build()).toEqual(`$where=(foo=in=%22bar%22%20or%20bar=in=%22baz%22)`);
+    expect(criteria1.build({ encodeString: false })).toEqual(
+      `$where=(foo=in="bar" or bar=in="baz")`
     );
   });
 });

--- a/test/rsql-filter-builder.test.ts
+++ b/test/rsql-filter-builder.test.ts
@@ -5,19 +5,13 @@ import { TestOperator } from './test-operator';
 describe('RSQLFilterBuilder', () => {
   it('should build a single filter properly', () => {
     const builder: RSQLFilterBuilder = new RSQLFilterBuilder();
-    const list = builder
-      .column('blah')
-      .equalTo('123')
-      .toList();
+    const list = builder.column('blah').equalTo('123').toList();
     expect(list.build()).toEqual(`blah=in=${encodeURIComponent('"123"')}`);
   });
 
   it('should build a single filter properly by casting the result of the RSQLFilterBuilder to the RSQLFilter interface', () => {
     const builder: RSQLFilter = new RSQLFilterBuilder();
-    const list = builder
-      .column('blah')
-      .equalTo('123')
-      .toList();
+    const list = builder.column('blah').equalTo('123').toList();
     expect(list.build()).toEqual(`blah=in=${encodeURIComponent('"123"')}`);
   });
 
@@ -35,33 +29,28 @@ describe('RSQLFilterBuilder', () => {
         ' and '
       )}name=in=${encodeURIComponent('"John"')})`
     );
+    expect(list.build({encodeString: false})).toEqual(
+      `(blah=in="123" and name=in="John")`
+    );
   });
 
   it('should build a set of filters with an or', () => {
     const builder: RSQLFilter = new RSQLFilterBuilder();
-    const list = builder
-      .column('blah')
-      .equalTo('123')
-      .or()
-      .column('name')
-      .equalTo('John')
-      .toList();
+    const list = builder.column('blah').equalTo('123').or().column('name').equalTo('John').toList();
     expect(list.build()).toEqual(
       `(blah=in=${encodeURIComponent('"123"')}${encodeURIComponent(
         ' or '
       )}name=in=${encodeURIComponent('"John"')})`
+    );
+
+    expect(list.build({encodeString: false})).toEqual(
+      `(blah=in="123" or name=in="John")`
     );
   });
 
   it('should handle the clear function', () => {
     const builder: RSQLFilter = new RSQLFilterBuilder();
-    let list = builder
-      .column('blah')
-      .equalTo('123')
-      .or()
-      .column('name')
-      .equalTo('John')
-      .toList();
+    let list = builder.column('blah').equalTo('123').or().column('name').equalTo('John').toList();
     expect(list.build()).toEqual(
       `(blah=in=${encodeURIComponent('"123"')}${encodeURIComponent(
         ' or '
@@ -69,22 +58,13 @@ describe('RSQLFilterBuilder', () => {
     );
 
     builder.clear();
-    list = builder
-      .column('blah')
-      .equalTo('123')
-      .toList();
+    list = builder.column('blah').equalTo('123').toList();
     expect(list.build()).toEqual(`blah=in=${encodeURIComponent('"123"')}`);
   });
 
   it('should handle the clear function for complex functions', () => {
     const builder: RSQLFilter = new RSQLFilterBuilder();
-    let list = builder
-      .column('blah')
-      .equalTo('123')
-      .or()
-      .column('name')
-      .equalTo('John')
-      .toList();
+    let list = builder.column('blah').equalTo('123').or().column('name').equalTo('John').toList();
     expect(list.build()).toEqual(
       `(blah=in=${encodeURIComponent('"123"')}${encodeURIComponent(
         ' or '
@@ -92,13 +72,7 @@ describe('RSQLFilterBuilder', () => {
     );
 
     builder.clear();
-    list = builder
-      .column('blah2')
-      .equalTo('123')
-      .or()
-      .column('name2')
-      .equalTo('John')
-      .toList();
+    list = builder.column('blah2').equalTo('123').or().column('name2').equalTo('John').toList();
     expect(list.build()).toEqual(
       `(blah2=in=${encodeURIComponent('"123"')}${encodeURIComponent(
         ' or '
@@ -108,161 +82,121 @@ describe('RSQLFilterBuilder', () => {
 
   it('should build the proper string for the equalTo function', () => {
     const builder: RSQLFilter = new RSQLFilterBuilder();
-    let list = builder
-      .column('blah')
-      .equalTo('123')
-      .toList();
+    let list = builder.column('blah').equalTo('123').toList();
     expect(list.build()).toEqual(`blah=in=${encodeURIComponent('"123"')}`);
 
     builder.clear();
-    list = builder
-      .column('blah')
-      .equalTo(true)
-      .toList();
+    list = builder.column('blah').equalTo(true).toList();
     expect(list.build()).toEqual(`blah=in=true`);
+  });
+
+  it('should build the proper string for the equalTo function with special character', () => {
+    const builder: RSQLFilter = new RSQLFilterBuilder();
+    let list = builder.column('blah').equalTo('12_3').toList();
+    expect(list.build()).toEqual(`blah=in=${encodeURIComponent('"12_3"')}`);
+
+    builder.clear();
+    list = builder.column('blah').equalTo('12%5F3').toList();
+    expect(list.build({ encodeString: false })).toEqual(`blah=in="12%5F3"`);
   });
 
   it('should build the proper string for the notEqualTo function', () => {
     const builder: RSQLFilter = new RSQLFilterBuilder();
-    const list = builder
-      .column('blah')
-      .notEqualTo('123')
-      .toList();
+    const list = builder.column('blah').notEqualTo('123').toList();
     expect(list.build()).toEqual(`blah!=${encodeURIComponent('"123"')}`);
   });
 
   it('should build the proper string for the like function', () => {
     const builder: RSQLFilter = new RSQLFilterBuilder();
-    const list = builder
-      .column('blah')
-      .like('123')
-      .toList();
+    const list = builder.column('blah').like('123').toList();
     expect(list.build()).toEqual(`blah==${encodeURIComponent('"123"')}`);
   });
 
   it('should build the proper string for the contains function', () => {
     const builder: RSQLFilter = new RSQLFilterBuilder();
-    const list = builder
-      .column('blah')
-      .contains('123')
-      .toList();
+    const list = builder.column('blah').contains('123').toList();
     expect(list.build()).toEqual(`blah==${encodeURIComponent('"*123*"')}`);
   });
 
   it('should build the proper string for the doesNotContains function', () => {
     const builder: RSQLFilter = new RSQLFilterBuilder();
-    const list = builder
-      .column('blah')
-      .doesNotContain('123')
-      .toList();
+    const list = builder.column('blah').doesNotContain('123').toList();
     expect(list.build()).toEqual(`blah!=${encodeURIComponent('"*123*"')}`);
   });
 
   it('should build the proper string for the startsWith function', () => {
     const builder: RSQLFilter = new RSQLFilterBuilder();
-    const list = builder
-      .column('blah')
-      .startsWith('123')
-      .toList();
+    const list = builder.column('blah').startsWith('123').toList();
     expect(list.build()).toEqual(`blah==${encodeURIComponent('"123*"')}`);
   });
 
   it('should build the proper string for the endsWith function', () => {
     const builder: RSQLFilter = new RSQLFilterBuilder();
-    const list = builder
-      .column('blah')
-      .endsWith('123')
-      .toList();
+    const list = builder.column('blah').endsWith('123').toList();
     expect(list.build()).toEqual(`blah==${encodeURIComponent('"*123"')}`);
   });
 
   it('should build the proper string for the greaterThan function for a number', () => {
     const builder: RSQLFilter = new RSQLFilterBuilder();
-    const list = builder
-      .column('blah')
-      .greaterThan(123)
-      .toList();
+    const list = builder.column('blah').greaterThan(123).toList();
     expect(list.build()).toEqual(`blah${encodeURIComponent('>')}123`);
+    expect(list.build({encodeString: false})).toEqual(`blah>123`);
   });
 
   it('should build the proper string for the greaterThanOrEqualTo function', () => {
     const builder: RSQLFilter = new RSQLFilterBuilder();
-    const list = builder
-      .column('blah')
-      .greaterThanOrEqualTo('123')
-      .toList();
+    const list = builder.column('blah').greaterThanOrEqualTo('123').toList();
     expect(list.build()).toEqual(`blah${encodeURIComponent('>=')}123`);
+    expect(list.build({encodeString: false})).toEqual(`blah>=123`);
   });
 
   it('should build the proper string for the lessThan function', () => {
     const builder: RSQLFilter = new RSQLFilterBuilder();
-    const list = builder
-      .column('blah')
-      .lessThan('123')
-      .toList();
+    const list = builder.column('blah').lessThan('123').toList();
     expect(list.build()).toEqual(`blah${encodeURIComponent('<')}123`);
+    expect(list.build({encodeString: false})).toEqual(`blah<123`);
   });
 
   it('should build the proper string for the lessThanOrEqualTo function', () => {
     const builder: RSQLFilter = new RSQLFilterBuilder();
-    const list = builder
-      .column('blah')
-      .lessThanOrEqualTo('123')
-      .toList();
+    const list = builder.column('blah').lessThanOrEqualTo('123').toList();
     expect(list.build()).toEqual(`blah${encodeURIComponent('<=')}123`);
+    expect(list.build({encodeString: false})).toEqual(`blah<=123`);
   });
 
   it('should build the proper string for the in function', () => {
     const builder: RSQLFilter = new RSQLFilterBuilder();
-    const list = builder
-      .column('blah')
-      .in([123, 'abc'])
-      .toList();
+    const list = builder.column('blah').in([123, 'abc']).toList();
     expect(list.build()).toEqual(`blah=in=(123,${encodeURIComponent('"abc"')})`);
   });
 
   it('should build the proper string for the notIn function', () => {
     const builder: RSQLFilter = new RSQLFilterBuilder();
-    const list = builder
-      .column('blah')
-      .notIn(['abc', 123])
-      .toList();
+    const list = builder.column('blah').notIn(['abc', 123]).toList();
     expect(list.build()).toEqual(`blah=out=(${encodeURIComponent('"abc"')},123)`);
   });
 
   it('should build the proper string for the isNull function', () => {
     const builder: RSQLFilter = new RSQLFilterBuilder();
-    const list = builder
-      .column('blah')
-      .isNull()
-      .toList();
+    const list = builder.column('blah').isNull().toList();
     expect(list.build()).toEqual('blah==null');
   });
 
   it('should build the proper string for the isNotNull function', () => {
     const builder: RSQLFilter = new RSQLFilterBuilder();
-    const list = builder
-      .column('blah')
-      .isNotNull()
-      .toList();
+    const list = builder.column('blah').isNotNull().toList();
     expect(list.build()).toEqual('blah!=null');
   });
 
   it('should build the proper string for the isEmpty function', () => {
     const builder: RSQLFilter = new RSQLFilterBuilder();
-    const list = builder
-      .column('blah')
-      .isEmpty()
-      .toList();
+    const list = builder.column('blah').isEmpty().toList();
     expect(list.build()).toEqual(`blah==${encodeURIComponent('""')}`);
   });
 
   it('should build the proper string for the isNotEmpty function', () => {
     const builder: RSQLFilter = new RSQLFilterBuilder();
-    const list = builder
-      .column('blah')
-      .isNotEmpty()
-      .toList();
+    const list = builder.column('blah').isNotEmpty().toList();
     expect(list.build()).toEqual(`blah!=${encodeURIComponent('""')}`);
   });
 
@@ -297,10 +231,7 @@ describe('RSQLFilterBuilder', () => {
 
   it('should allow the use of custom operations', () => {
     const builder: RSQLFilter = new RSQLFilterBuilder();
-    const list = builder
-      .column('blah')
-      .custom(new TestOperator(), 'support')
-      .toList();
+    const list = builder.column('blah').custom(new TestOperator(), 'support').toList();
     expect(list.build()).toEqual(`blah=custom=${encodeURIComponent('"support"')}`);
   });
 });

--- a/test/rsql-filter-expresion.test.ts
+++ b/test/rsql-filter-expresion.test.ts
@@ -12,6 +12,10 @@ describe('RSQLFilterExpression', () => {
 
     ex = new RSQLFilterExpression('code', Operators.Equal, 'ab"c');
     expect(ex.build()).toEqual(`code=in=%22ab%5C%22c%22`);
+    expect(ex.build({ encodeString: false })).toEqual(`code=in="ab\\"c"`);
+
+    ex = new RSQLFilterExpression('code', Operators.Equal, 'ab%22c');
+    expect(ex.build({ encodeString: false })).toEqual(`code=in="ab%22c"`);
 
     ex = new RSQLFilterExpression('code', Operators.Equal, 'ab\\c');
     expect(ex.build()).toEqual(`code=in=%22ab%5C%5Cc%22`);
@@ -21,6 +25,7 @@ describe('RSQLFilterExpression', () => {
 
     ex = new RSQLFilterExpression('code', Operators.Equal, 123);
     expect(ex.build()).toEqual(`code=in=123`);
+    expect(ex.build({ encodeString: false })).toEqual(`code=in=123`);
   });
 
   it('should handle the Equals operator when our value is null', () => {
@@ -36,9 +41,11 @@ describe('RSQLFilterExpression', () => {
   it('should handle the NotEquals operator', () => {
     let ex = new RSQLFilterExpression('code', Operators.NotEqual, '123');
     expect(ex.build()).toEqual(`code!=${encodeURIComponent('"123"')}`);
+    expect(ex.build({ encodeString: false })).toEqual(`code!="123"`);
 
     ex = new RSQLFilterExpression('code', Operators.NotEqual, true);
     expect(ex.build()).toEqual(`code!=true`);
+    expect(ex.build({ encodeString: false })).toEqual(`code!=true`);
   });
 
   it('should handle the Like operator', () => {
@@ -47,6 +54,9 @@ describe('RSQLFilterExpression', () => {
 
     ex = new RSQLFilterExpression('code', Operators.Like, 'ab_d');
     expect(ex.build()).toEqual(`code==${encodeURIComponent('"ab_d"')}`);
+
+    ex = new RSQLFilterExpression('code', Operators.Like, 'ab%5Fd');
+    expect(ex.build({ encodeString: false })).toEqual(`code=="ab%5Fd"`);
   });
 
   it('should handle the IsNull operator', () => {
@@ -62,51 +72,61 @@ describe('RSQLFilterExpression', () => {
   it('should handle the GreaterThan operator', () => {
     const ex = new RSQLFilterExpression('code', Operators.GreaterThan, 123);
     expect(ex.build()).toEqual(`code${encodeURIComponent('>')}123`);
+    expect(ex.build({encodeString: false})).toEqual(`code>123`);
   });
 
   it('should handle the GreaterThanEqualTo operator', () => {
     const ex = new RSQLFilterExpression('code', Operators.GreaterThanEqualTo, 123);
     expect(ex.build()).toEqual(`code${encodeURIComponent('>=')}123`);
+    expect(ex.build({encodeString: false})).toEqual(`code>=123`);
   });
 
   it('should handle the LessThan operator', () => {
     const ex = new RSQLFilterExpression('code', Operators.LessThan, 123);
     expect(ex.build()).toEqual(`code${encodeURIComponent('<')}123`);
+    expect(ex.build({encodeString: false})).toEqual(`code<123`);
   });
 
   it('should handle the LessThanEqualTo operator', () => {
     const ex = new RSQLFilterExpression('code', Operators.LessThanEqualTo, 123);
     expect(ex.build()).toEqual(`code${encodeURIComponent('<=')}123`);
+    expect(ex.build({encodeString: false})).toEqual(`code<=123`);
   });
 
   it('should handle the StartsWith operator', () => {
     const ex = new RSQLFilterExpression('code', Operators.StartsWith, '123');
     expect(ex.build()).toEqual(`code==${encodeURIComponent('"123*"')}`);
+    expect(ex.build({ encodeString: false })).toEqual(`code=="123*"`);
   });
 
   it('should handle the EndsWith operator', () => {
     const ex = new RSQLFilterExpression('code', Operators.EndsWith, '123');
     expect(ex.build()).toEqual(`code==${encodeURIComponent('"*123"')}`);
+    expect(ex.build({ encodeString: false })).toEqual(`code=="*123"`);
   });
 
   it('should handle the Contains operator', () => {
     const ex = new RSQLFilterExpression('code', Operators.Contains, '123');
     expect(ex.build()).toEqual(`code==${encodeURIComponent('"*123*"')}`);
+    expect(ex.build({ encodeString: false })).toEqual(`code=="*123*"`);
   });
 
   it('should handle the DoesNotContain operator', () => {
     const ex = new RSQLFilterExpression('code', Operators.DoesNotContain, '123');
     expect(ex.build()).toEqual(`code!=${encodeURIComponent('"*123*"')}`);
+    expect(ex.build({ encodeString: false })).toEqual(`code!="*123*"`);
   });
 
   it('should handle the IsEmpty operator', () => {
     const ex = new RSQLFilterExpression('code', Operators.IsEmpty, '123');
     expect(ex.build()).toEqual('code==%22%22');
+    expect(ex.build({encodeString: false})).toEqual('code==""');
   });
 
   it('should handle the IsNotEmpty operator', () => {
     const ex = new RSQLFilterExpression('code', Operators.IsNotEmpty, '123');
     expect(ex.build()).toEqual('code!=%22%22');
+    expect(ex.build({encodeString: false})).toEqual('code!=""');
   });
 
   it('should handle the In operator', () => {
@@ -114,14 +134,21 @@ describe('RSQLFilterExpression', () => {
     expect(ex.build()).toEqual(
       `code=in=(${encodeURIComponent('"123"')},${encodeURIComponent('"456"')})`
     );
+    expect(ex.build({ encodeString: false })).toEqual(`code=in=("123","456")`);
 
     ex = new RSQLFilterExpression('code', Operators.In, ['ab"c', 'ab\\c', 'ab\\"c']);
     expect(ex.build()).toEqual(`code=in=(%22ab%5C%22c%22,%22ab%5C%5Cc%22,%22ab%5C%5C%5C%22c%22)`);
+
+    ex = new RSQLFilterExpression('code', Operators.In, ['ab%22c', 'ab%5Cc', 'ab%5C%22c']);
+    expect(ex.build({ encodeString: false })).toEqual(
+      `code=in=("ab%22c","ab%5Cc","ab%5C%22c")`
+    );
   });
 
   it('should handle the In operator with only numbers', () => {
     const ex = new RSQLFilterExpression('code', Operators.In, [123, 456]);
     expect(ex.build()).toEqual('code=in=(123,456)');
+    expect(ex.build({ encodeString: false })).toEqual('code=in=(123,456)');
   });
 
   it('should handle the In operator with numbers, strings, and booleans', () => {
@@ -129,6 +156,7 @@ describe('RSQLFilterExpression', () => {
     expect(ex.build()).toEqual(
       `code=in=(${encodeURIComponent('"123"')},456,${encodeURIComponent('"true"')})`
     );
+    expect(ex.build({ encodeString: false })).toEqual(`code=in=("123",456,"true")`);
   });
 
   it('should handle the NotIn operator', () => {


### PR DESCRIPTION
New build() time option has been created to provide a way to use this library with pre-encoded
values.

re #19